### PR TITLE
[Enhancement] Add diff view for mobile

### DIFF
--- a/src/components/WIKI/WikiEngine.jsx
+++ b/src/components/WIKI/WikiEngine.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ReactDiffViewer from 'react-diff-viewer-continued';
 import { toRelativeTime } from '../../utils/Time';
+import useWindowDimensions from '../../hooks/useWindowDimensions';
 
 const WikiContent = ({ author, DocTitle, content, notFoundFlag, history, prevContent }) => {
   const [toc, setToc] = useState([]);
@@ -11,6 +12,7 @@ const WikiContent = ({ author, DocTitle, content, notFoundFlag, history, prevCon
   const [isHistoryVisible, setIsHistoryVisible] = useState(history === undefined ? true : false);
   const navigate = useNavigate();
   let accessToken = localStorage.getItem("accessToken");
+  const { height, width } = useWindowDimensions();
 
   const applyFormatting = (text) => {
     text = text.replace(/\|\|(.+?)\|\|/g, '<b>$1</b>');
@@ -202,7 +204,7 @@ const WikiContent = ({ author, DocTitle, content, notFoundFlag, history, prevCon
       )}
 
       {isHistoryVisible && prevContent && (
-        <ReactDiffViewer oldValue={prevContent} newValue={content} splitView={true} />
+        <ReactDiffViewer oldValue={prevContent} newValue={content} splitView={width > 768} hideLineNumbers={width <= 768} />
       )}
 
       {comments.length > 0 && isContentVisible && (

--- a/src/hooks/useWindowDimensions.js
+++ b/src/hooks/useWindowDimensions.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+const getWindowDimensions = () => {
+  const { innerWidth: width, innerHeight: height } = window;
+  return { width, height };
+};
+
+const useWindowDimensions = () => {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowDimensions(getWindowDimensions());
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  return windowDimensions;
+};
+
+export default useWindowDimensions;


### PR DESCRIPTION
## 📌 변경 사항 요약

모바일 diff viewer 추가

## 🔍 상세 내용

- 모바일에서는(폭이 768이하일 때) diff view에 line number를 제거하고 split을 unified로 보여준다.

## 📸 스크린샷

<img width="526" alt="스크린샷 2025-03-28 오후 11 02 33" src="https://github.com/user-attachments/assets/6025fa10-6a13-43c7-9185-5439fc7c9904" />


## ✅ 테스트 항목

- [ ] 모바일에서 정상 표출
- [ ] PC에서 정상 표출

## 🔄 관련 이슈

close: #14 
