### PR TITLE
[fix] 위키 텍스트 서식 및 외부 링크 처리 수정

### DIFF
--- a/src/components/WIKI/WikiEngine.tsx
+++ b/src/components/WIKI/WikiEngine.tsx
@@ -19,6 +19,10 @@ const ALLOWED_TAGS = [
   "ol",
   "li",
   "a",
+  "b",
+  "i",
+  "u",
+  "s",
   "strong",
   "em",
   "code",
@@ -31,7 +35,7 @@ const ALLOWED_TAGS = [
   "sup",
 ];
 
-const ALLOWED_ATTR = ["href", "class", "id", "style", "data-comment-index"];
+const ALLOWED_ATTR = ["href", "target", "rel", "class", "id", "style", "data-comment-index"];
 
 const FORBID_TAGS = ["iframe", "script"];
 const FORBID_ATTR = ["onerror", "onclick", "onload", /^on.*/] as const;
@@ -81,11 +85,18 @@ function applyFormatting(text: string): string {
 }
 
 function wikiLinkReplace(_: string, linkText: string): string {
-  const [text] = linkText.split("|");
-  const link_text = text ? text.replace(/ /g, "+") : null;
-  return text
-    ? `<a href="/wiki/${link_text}" class="text-blue-500 hover:underline">${text}</a>`
-    : `<a href="#" class="text-blue-500 hover:underline">${text}</a>`;
+  const [text, href] = linkText.split("|").map((s) => s.trim());
+  if (!text) return "";
+
+  const isExternal = href && /^https?:\/\//i.test(href);
+
+  if (isExternal) {
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">${text}</a>`;
+  }
+
+  const target = href ?? text;
+  const link_text = target.replace(/ /g, "+");
+  return `<a href="/wiki/${link_text}" class="text-blue-500 hover:underline">${text}</a>`;
 }
 
 function parseContent(text: string): {


### PR DESCRIPTION
- ALLOWED_TAGS에 b, i, u, s 추가 (DOMPurify가 서식 태그 제거하던 문제 해결)
- ALLOWED_ATTR에 target, rel 추가 (외부 링크 새 탭 열기 지원)
- wikiLinkReplace: [[표시|https://...]] 형식의 외부 링크를 target="_blank"로 처리

## 📌 변경 사항 요약

[변경 사항에 대한 간결한 설명]

## 🔍 상세 내용

[변경 사항에 대한 자세한 설명, 필요한 배경 정보]

## 📸 스크린샷

[UI 변경이 있을 경우 스크린샷 첨부]

## ✅ 테스트 항목

- [ ] 테스트 항목 1
- [ ] 테스트 항목 2
- [ ] 테스트 항목 3

## 🔄 관련 이슈

[관련 이슈 번호 (예: #123)]

## 🧩 기타 참고 사항

[추가 참고 사항, 주의점 등]
