### PR TITLE
[feat] 위키 문법 처리 확장 (CAPS 문서 스펙 정렬)

### DIFF
--- a/src/components/WIKI/WikiEngine.tsx
+++ b/src/components/WIKI/WikiEngine.tsx
@@ -33,9 +33,21 @@ const ALLOWED_TAGS = [
   "br",
   "hr",
   "sup",
+  "img",
 ];
 
-const ALLOWED_ATTR = ["href", "target", "rel", "class", "id", "style", "data-comment-index"];
+const ALLOWED_ATTR = [
+  "href",
+  "src",
+  "alt",
+  "target",
+  "rel",
+  "class",
+  "id",
+  "style",
+  "data-comment-index",
+  "loading",
+];
 
 const FORBID_TAGS = ["iframe", "script"];
 const FORBID_ATTR = ["onerror", "onclick", "onload", /^on.*/] as const;
@@ -74,29 +86,170 @@ function stripForbiddenHtml(text: string): string {
   return result;
 }
 
+/** `!||`, `!//` 등 문법 설명용 리터럴 — 포맷 적용 전에 치환했다가 끝에서 복원 */
 function applyFormatting(text: string): string {
   let out = stripForbiddenHtml(text);
+  const literals: string[] = [];
+  const pushLiteral = (raw: string): string => {
+    const id = literals.length;
+    literals.push(raw);
+    return `\uE000W${id}\uE001`;
+  };
+
+  out = out.replace(/!\|\|/g, () => pushLiteral("||"));
+  out = out.replace(/!\/\//g, () => pushLiteral("//"));
+  out = out.replace(/!__/g, () => pushLiteral("__"));
+  out = out.replace(/!--/g, () => pushLiteral("--"));
+
   out = out.replace(/\|\|(.+?)\|\|/g, "<b>$1</b>");
   out = out.replace(/\/\/(.+?)\/\//g, "<i>$1</i>");
   out = out.replace(/__(.+?)__/g, "<u>$1</u>");
   out = out.replace(/--(.+?)--/g, "<s>$1</s>");
-  out = out.replace(/\(\((.+?)\)\)/g, "<pre>$1</pre>");
+
+  /* 문서의 "틀": 멀티라인 허용, 본문 문법은 아래 단계에서 계속 처리됨 */
+  out = out.replace(
+    /\(\(([\s\S]+?)\)\)/g,
+    '<div class="wiki-frame border border-gray-200 rounded-lg p-4 my-4 bg-gray-50 shadow-sm text-gray-800">$1</div>'
+  );
+
+  for (let i = literals.length - 1; i >= 0; i--) {
+    out = out.replace(new RegExp(`\\uE000W${i}\\uE001`, "g"), literals[i]);
+  }
+
   return out;
 }
 
-function wikiLinkReplace(_: string, linkText: string): string {
-  const [text, href] = linkText.split("|").map((s) => s.trim());
-  if (!text) return "";
+/** 위키 링크 안에서 ASCII `|` 또는 전각 `｜`으로 한 번만 분리 (한글 입력기 전각 파이프 대응) */
+function splitWikiLinkTarget(linkText: string): [string] | [string, string] {
+  const ascii = linkText.indexOf("|");
+  const full = linkText.indexOf("｜");
+  let idx = -1;
+  if (ascii >= 0 && full >= 0) idx = Math.min(ascii, full);
+  else idx = ascii >= 0 ? ascii : full;
 
-  const isExternal = href && /^https?:\/\//i.test(href);
+  if (idx === -1) return [linkText.trim()];
+  const left = linkText.slice(0, idx).trim();
+  const right = linkText.slice(idx + 1).trim();
+  return [left, right];
+}
 
-  if (isExternal) {
-    return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">${text}</a>`;
+function looksLikeAbsoluteHttpUrl(s: string): boolean {
+  const t = s.trim();
+  return /^https?:\/\//i.test(t) || /^\/\//.test(t);
+}
+
+function isProbablyImageUrl(url: string): boolean {
+  const pathOnly = url.trim().split("?")[0].split("#")[0];
+  return /\.(png|jpe?g|gif|webp|svg|bmp|ico)$/i.test(pathOnly);
+}
+
+function externalLinkOrImg(label: string, rawHref: string): string {
+  const hrefNorm = rawHref.trim().startsWith("//")
+    ? `https:${rawHref.trim()}`
+    : rawHref.trim();
+
+  if (isProbablyImageUrl(hrefNorm)) {
+    return `<img src="${escapeHtmlAttr(hrefNorm)}" alt="${escapeWikiLinkLabel(label)}" class="max-w-full h-auto rounded-md my-3 border border-gray-200 shadow-sm" loading="lazy" />`;
   }
 
-  const target = href ?? text;
-  const link_text = target.replace(/ /g, "+");
-  return `<a href="/wiki/${link_text}" class="text-blue-500 hover:underline">${text}</a>`;
+  return `<a href="${escapeHtmlAttr(hrefNorm)}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">${escapeWikiLinkLabel(label)}</a>`;
+}
+
+/** `<pre>` 블록은 원문 유지 (예제·코드 안의 [[ ]] 등 파손 방지) */
+function splitPreservingPre(html: string): string[] {
+  const re = /<pre\b[^>]*>[\s\S]*?<\/pre>/gi;
+  const chunks: string[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    chunks.push(html.slice(last, m.index));
+    chunks.push(m[0]);
+    last = re.lastIndex;
+  }
+  chunks.push(html.slice(last));
+  return chunks;
+}
+
+function transformOutsidePre(html: string, fn: (frag: string) => string): string {
+  const chunks = splitPreservingPre(html);
+  return chunks.map((c, i) => (i % 2 === 1 ? c : fn(c))).join("");
+}
+
+/** `![[ … ]]` 리터럴 표시 후 `[[ … ]]` 처리 */
+function processWikiLinkSyntax(fragment: string): string {
+  let s = fragment.replace(/!\[\[([^\]]+?)\]\]/g, (_, inner: string) => {
+    return `<span class="wiki-literal text-gray-800 font-mono text-sm">[[${escapeWikiLinkLabel(inner)}]]</span>`;
+  });
+  s = s.replace(/\[\[([^\]]+?)\]\]/g, wikiLinkReplace);
+  return s;
+}
+
+function applyMarkdownLinks(fragment: string): string {
+  return fragment.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+    (_, label: string, url: string) =>
+      `<a href="${escapeHtmlAttr(url)}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">${escapeWikiLinkLabel(label)}</a>`
+  );
+}
+
+/** 속성값용 이스케이프 (href 등) */
+function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/\u0000/g, "");
+}
+
+/** 텍스트 노드용 (링크 표시글자) */
+function escapeWikiLinkLabel(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function wikiLinkReplace(_: string, linkText: string): string {
+  const parts = splitWikiLinkTarget(linkText);
+
+  /* 두 조각: [[표시글|대상]] 또는 [[URL|표시글]] 둘 다 허용 */
+  if (parts.length === 2) {
+    const [a, b] = parts;
+    if (!a && !b) return "";
+
+    let label: string;
+    let rawHref: string;
+
+    if (looksLikeAbsoluteHttpUrl(b)) {
+      label = a || b;
+      rawHref = b;
+    } else if (looksLikeAbsoluteHttpUrl(a)) {
+      label = b || a;
+      rawHref = a;
+    } else {
+      label = a;
+      const target = b;
+      const linkSlug = target.replace(/ /g, "+");
+      return `<a href="/wiki/${linkSlug}" class="text-blue-500 hover:underline">${escapeWikiLinkLabel(label)}</a>`;
+    }
+
+    const hrefNorm =
+      rawHref.trim().startsWith("//") ? `https:${rawHref.trim()}` : rawHref.trim();
+
+    return externalLinkOrImg(label, hrefNorm);
+  }
+
+  /* 한 조각: 전체가 URL이면 외부 링크, 아니면 내부 위키 */
+  const only = parts[0];
+  if (!only) return "";
+
+  if (looksLikeAbsoluteHttpUrl(only)) {
+    const hrefNorm = only.trim().startsWith("//") ? `https:${only.trim()}` : only.trim();
+    return externalLinkOrImg(only, hrefNorm);
+  }
+
+  const linkSlug = only.replace(/ /g, "+");
+  return `<a href="/wiki/${linkSlug}" class="text-blue-500 hover:underline">${escapeWikiLinkLabel(only)}</a>`;
 }
 
 function parseContent(text: string): {
@@ -138,10 +291,7 @@ function parseContent(text: string): {
       const id = `section-${tocList.length + 1}`;
       const headingRank = 6 - level;
 
-      const subtitleWithLinks = title.replace(
-        /\[\[([^\]]+?)\]\]/g,
-        wikiLinkReplace
-      );
+      const subtitleWithLinks = processWikiLinkSyntax(title);
 
       tocList.push({
         id,
@@ -156,7 +306,9 @@ function parseContent(text: string): {
     }
   );
 
-  htmlContent = htmlContent.replace(/\[\[([^\]]+?)\]\]/g, wikiLinkReplace);
+  htmlContent = transformOutsidePre(htmlContent, (frag) =>
+    applyMarkdownLinks(processWikiLinkSyntax(frag))
+  );
 
   htmlContent = htmlContent.replace(/\{\{(.+?)\}\}/g, (_, commentText: string) => {
     const commentIndex = commentList.length + 1;
@@ -166,12 +318,17 @@ function parseContent(text: string): {
   });
 
   htmlContent = htmlContent.replace(
-    /^\* (.+)$/gm,
+    /^\*\s+(.+)$/gm,
+    '<li class="text-lg text-gray-600">$1</li>'
+  );
+  /* 나무위키식 · / ㆍ 줄머리 */
+  htmlContent = htmlContent.replace(
+    /^[\u318d\u00b7]\s+(.+)$/gm,
     '<li class="text-lg text-gray-600">$1</li>'
   );
   htmlContent = htmlContent.replace(
-    /(<li>.*<\/li>)(?!.*<\/ul>)/g,
-    '<ul class="list-disc pl-6">$1</ul>'
+    /(?:<li\b[^>]*>[\s\S]*?<\/li>\s*)+/g,
+    (block) => `<ul class="list-disc pl-6 my-2">${block.trim()}</ul>`
   );
 
   htmlContent = htmlContent.replace(
@@ -236,10 +393,11 @@ const WikiEngine: React.FC<WikiEngineProps> = ({
 
   useEffect(() => {
     const redirectToHashPage = (text: string) => {
-      const hashPattern = /^#(\S+)/g;
-      const match = hashPattern.exec(text);
+      const firstLine =
+        text.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "";
+      const match = /^#(\S+)/.exec(firstLine);
       if (match) {
-        const targetPage = text.replace("#", "");
+        const targetPage = firstLine.slice(1).trim();
         setTimeout(() => {
           navigate(`/wiki/${targetPage}`);
         }, 500);


### PR DESCRIPTION
- !|| 등 포맷 이스케이프 후 치환/복원
- (( ))를 틀용 div(wiki-frame)로 처리, 멀티라인 허용
- pre 블록 밖에서만 [[ ]]·마크다운 링크 처리 (예제 내 리터럴 보존)
- ![[…]] 리터럴 표시
- 이미지 확장자 링크는 img 출력·sanitize 허용
- 리스트 ul 감싸기 수정 및 ㆍ·중점 줄머리 지원
- 리다이렉트는 첫 번째 비어 있지 않은 줄만 검사

## 📌 변경 사항 요약

[변경 사항에 대한 간결한 설명]

## 🔍 상세 내용

[변경 사항에 대한 자세한 설명, 필요한 배경 정보]

## 📸 스크린샷

[UI 변경이 있을 경우 스크린샷 첨부]

## ✅ 테스트 항목

- [ ] 테스트 항목 1
- [ ] 테스트 항목 2
- [ ] 테스트 항목 3

## 🔄 관련 이슈

[관련 이슈 번호 (예: #123)]

## 🧩 기타 참고 사항

[추가 참고 사항, 주의점 등]
