### PR TITLE
feat: 위키 로그인 전용 전환 + 상대시간 표기 버그 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,11 @@ const App: React.FC = () => {
     },
     {
       path: "/wiki",
-      element: <WikiPage />,
+      element: (
+        <ProtectedRoute>
+          <WikiPage />
+        </ProtectedRoute>
+      ),
       children: [
         {
           path: ":wiki_title",
@@ -147,11 +151,19 @@ const App: React.FC = () => {
     },
     {
       path: "/wiki/history/:wiki_title",
-      element: <WikiHistoryPage />,
+      element: (
+        <ProtectedRoute>
+          <WikiHistoryPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "/wiki/edit/:wiki_title",
-      element: <WikiEditPage />,
+      element: (
+        <ProtectedRoute>
+          <WikiEditPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "*",

--- a/src/components/WIKI/WikiRecent.tsx
+++ b/src/components/WIKI/WikiRecent.tsx
@@ -10,7 +10,9 @@ const WikiRecent: React.FC = () => {
   const { data: recentWikis, isLoading } = useQuery<WikiRecentData[]>({
     queryKey: ["recent-wikis"],
     queryFn: async () => {
-      const response = await axios.get(import.meta.env.VITE_API_HOST + "/api/v1/wikis/recent");
+      const response = await axios.get(import.meta.env.VITE_API_HOST + "/api/v1/wikis/recent", {
+        withCredentials: true,
+      });
       return response.data.data || [];
     },
   });

--- a/src/components/WIKI/WikiSearch.tsx
+++ b/src/components/WIKI/WikiSearch.tsx
@@ -17,7 +17,7 @@ const WikiSearch = () => {
   };
 
   const handleRandom = async () => {
-    const response = await axios.get(import.meta.env.VITE_API_HOST + '/api/v1/wikis/random')
+    const response = await axios.get(import.meta.env.VITE_API_HOST + '/api/v1/wikis/random', { withCredentials: true })
     const randomTitle = (response.data.data.title);
     navigate(`/wiki/${randomTitle}`); // 랜덤 페이지로 이동
   };

--- a/src/pages/WikiPage.tsx
+++ b/src/pages/WikiPage.tsx
@@ -23,7 +23,9 @@ const IntroducePage = () => {
   useEffect(() => {
     const fetchData = async (title) => {
       try {
-        const response = await axios.get(`${import.meta.env.VITE_API_HOST}/api/v1/wikis/${title}`);
+        const response = await axios.get(`${import.meta.env.VITE_API_HOST}/api/v1/wikis/${title}`, {
+          withCredentials: true,
+        });
         if (response.status === 200) {
           setWikiData(response.data.data); // Set the fetched data
           setError(null);

--- a/src/utils/Time.ts
+++ b/src/utils/Time.ts
@@ -23,7 +23,7 @@ export const toRelativeTime = (dateString: string): string => {
   }
 
   const diffInWeeks = Math.floor(diffInDays / 7);
-  if (diffInWeeks < 4) {
+  if (diffInDays < 30) {
     return `${diffInWeeks}주 전`;
   }
 
@@ -32,6 +32,6 @@ export const toRelativeTime = (dateString: string): string => {
     return `${diffInMonths}개월 전`;
   }
 
-  const diffInYears = Math.floor(diffInDays / 365);
+  const diffInYears = Math.floor(diffInMonths / 12);
   return `${diffInYears}년 전`;
 };


### PR DESCRIPTION
## Summary
프론트 변경 2건 (커밋 분리):

1. **fix: 상대시간 "0개월/0년 전" 버그** — 주→개월(28~29일), 개월→연(360~364일) 경계에서 상위 단위 상한과 다음 단위 나눗셈 기준이 어긋나 `0개월 전`/`0년 전`이 뜨던 문제를 일수 기준 경계로 통일해 해결.
2. **feat: 위키 열람 로그인 전용화** — 위키 본문/최근/랜덤/수정내역이 비로그인 상태로 열리던 문제 해결.
   - `/wiki`, `/wiki/history`, `/wiki/edit` 라우트를 `ProtectedRoute`로 감쌈
   - 쿠키 미포함 평문 axios 호출(본문·최근·랜덤)에 `withCredentials: true` 추가

## ⚠️ 배포 순서
실제 게이팅은 백엔드 `caps-server` SecurityConfig whiteList에서 wiki 공개 항목 제거가 함께 배포되어야 적용됨.
**프론트 선배포 → 백엔드 후배포** 순서 권장 (반대 순서면 구버전 프론트가 401을 못 받아 위키가 깨짐).
관련 백엔드 PR: CAPS-DGU/caps-server (별도)

## Test plan
- [x] `tsc --noEmit` 타입 체크 통과
- [x] Time.ts 경계값(6/7/27/28/29/30/59/60/359/360/364/365/730일) 출력 검증 — 0 표기 소멸 확인
- [ ] ⚠️ 로그인 상태 위키 열람 E2E는 본 환경에서 미검증(로컬 self-signed 인증서 CORS + 로그인 토큰 부재) — 리뷰어 수동 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)