### PR TITLE
chore: develop → main (위키 로그인 전용 + 상대시간 버그 수정)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,11 @@ const App: React.FC = () => {
     },
     {
       path: "/wiki",
-      element: <WikiPage />,
+      element: (
+        <ProtectedRoute>
+          <WikiPage />
+        </ProtectedRoute>
+      ),
       children: [
         {
           path: ":wiki_title",
@@ -147,11 +151,19 @@ const App: React.FC = () => {
     },
     {
       path: "/wiki/history/:wiki_title",
-      element: <WikiHistoryPage />,
+      element: (
+        <ProtectedRoute>
+          <WikiHistoryPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "/wiki/edit/:wiki_title",
-      element: <WikiEditPage />,
+      element: (
+        <ProtectedRoute>
+          <WikiEditPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "*",

--- a/src/components/MainPage/Footer.tsx
+++ b/src/components/MainPage/Footer.tsx
@@ -8,33 +8,32 @@ function Footer() {
         {/* CAPs 로고 */}
         <img src={logoBright} alt="CAPS Logo" className="w-24 mb-6" />
         <br className="md:hidden" />
-        {/* 인스타/링크트리/문의하기 */}
+        {/* FAQ/링크트리/문의하기/회칙 */}
         <div className="md:flex items-center justify-center gap-12 text-gray-200 text-lg mb-8">
+          {/* 공식 인스타그램 링크는 링크트리 안에 이미 포함되어 있어 FAQ로 대체 */}
           <a
-            href="https://www.instagram.com/caps_dongguk"
+            href="/faq"
             className="flex items-center gap-2 hover:text-blue-300 transition"
           >
-            {/* instagram icon */}
+            {/* FAQ icon */}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
-              viewBox="2 2 20 20"
+              viewBox="0 0 24 24"
               className="w-6 h-6"
               stroke="currentColor"
             >
-              <rect
-                width="16"
-                height="16"
-                x="4"
-                y="4"
-                rx="4"
+              <circle cx="12" cy="12" r="9" stroke="#ccc" strokeWidth="2" />
+              <path
+                d="M9.5 9.5a2.5 2.5 0 1 1 3.6 2.3c-.7.4-1.1 1-1.1 1.7v.5"
                 stroke="#ccc"
                 strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
-              <circle cx="12" cy="12" r="4" stroke="#ccc" strokeWidth="2" />
-              <circle cx="16.5" cy="7.5" r="1.5" fill="#ccc" />
+              <circle cx="12" cy="17" r="1" fill="#ccc" />
             </svg>
-            공식 인스타그램
+            FAQ
           </a>
           <br className="md:hidden" />
           <a

--- a/src/components/WIKI/WikiRecent.tsx
+++ b/src/components/WIKI/WikiRecent.tsx
@@ -10,7 +10,9 @@ const WikiRecent: React.FC = () => {
   const { data: recentWikis, isLoading } = useQuery<WikiRecentData[]>({
     queryKey: ["recent-wikis"],
     queryFn: async () => {
-      const response = await axios.get(import.meta.env.VITE_API_HOST + "/api/v1/wikis/recent");
+      const response = await axios.get(import.meta.env.VITE_API_HOST + "/api/v1/wikis/recent", {
+        withCredentials: true,
+      });
       return response.data.data || [];
     },
   });

--- a/src/components/WIKI/WikiSearch.tsx
+++ b/src/components/WIKI/WikiSearch.tsx
@@ -17,7 +17,7 @@ const WikiSearch = () => {
   };
 
   const handleRandom = async () => {
-    const response = await axios.get(import.meta.env.VITE_API_HOST + '/api/v1/wikis/random')
+    const response = await axios.get(import.meta.env.VITE_API_HOST + '/api/v1/wikis/random', { withCredentials: true })
     const randomTitle = (response.data.data.title);
     navigate(`/wiki/${randomTitle}`); // 랜덤 페이지로 이동
   };

--- a/src/pages/WikiPage.tsx
+++ b/src/pages/WikiPage.tsx
@@ -23,7 +23,9 @@ const IntroducePage = () => {
   useEffect(() => {
     const fetchData = async (title) => {
       try {
-        const response = await axios.get(`${import.meta.env.VITE_API_HOST}/api/v1/wikis/${title}`);
+        const response = await axios.get(`${import.meta.env.VITE_API_HOST}/api/v1/wikis/${title}`, {
+          withCredentials: true,
+        });
         if (response.status === 200) {
           setWikiData(response.data.data); // Set the fetched data
           setError(null);

--- a/src/utils/Time.ts
+++ b/src/utils/Time.ts
@@ -23,7 +23,7 @@ export const toRelativeTime = (dateString: string): string => {
   }
 
   const diffInWeeks = Math.floor(diffInDays / 7);
-  if (diffInWeeks < 4) {
+  if (diffInDays < 30) {
     return `${diffInWeeks}주 전`;
   }
 
@@ -32,6 +32,6 @@ export const toRelativeTime = (dateString: string): string => {
     return `${diffInMonths}개월 전`;
   }
 
-  const diffInYears = Math.floor(diffInDays / 365);
+  const diffInYears = Math.floor(diffInMonths / 12);
   return `${diffInYears}년 전`;
 };


### PR DESCRIPTION
## Summary
develop에 머지된 프론트 변경을 main(프로덕션)에 반영:
- fix: 상대시간 "0개월/0년 전" 표기 버그 (#106)
- feat: 위키 열람 로그인 전용화 (#106)

## ⚠️ 배포 순서 주의
위키 게이팅은 백엔드 caps-server whiteList 변경과 짝을 이룸.
**이 프론트를 먼저 배포**하고, 그 다음 백엔드를 배포해야 위키가 깨지지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)