### PR TITLE
feat: 푸터 공식 인스타그램 링크를 FAQ로 교체

### DIFF
--- a/src/components/MainPage/Footer.tsx
+++ b/src/components/MainPage/Footer.tsx
@@ -8,33 +8,32 @@ function Footer() {
         {/* CAPs 로고 */}
         <img src={logoBright} alt="CAPS Logo" className="w-24 mb-6" />
         <br className="md:hidden" />
-        {/* 인스타/링크트리/문의하기 */}
+        {/* FAQ/링크트리/문의하기/회칙 */}
         <div className="md:flex items-center justify-center gap-12 text-gray-200 text-lg mb-8">
+          {/* 공식 인스타그램 링크는 링크트리 안에 이미 포함되어 있어 FAQ로 대체 */}
           <a
-            href="https://www.instagram.com/caps_dongguk"
+            href="/faq"
             className="flex items-center gap-2 hover:text-blue-300 transition"
           >
-            {/* instagram icon */}
+            {/* FAQ icon */}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
-              viewBox="2 2 20 20"
+              viewBox="0 0 24 24"
               className="w-6 h-6"
               stroke="currentColor"
             >
-              <rect
-                width="16"
-                height="16"
-                x="4"
-                y="4"
-                rx="4"
+              <circle cx="12" cy="12" r="9" stroke="#ccc" strokeWidth="2" />
+              <path
+                d="M9.5 9.5a2.5 2.5 0 1 1 3.6 2.3c-.7.4-1.1 1-1.1 1.7v.5"
                 stroke="#ccc"
                 strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
-              <circle cx="12" cy="12" r="4" stroke="#ccc" strokeWidth="2" />
-              <circle cx="16.5" cy="7.5" r="1.5" fill="#ccc" />
+              <circle cx="12" cy="17" r="1" fill="#ccc" />
             </svg>
-            공식 인스타그램
+            FAQ
           </a>
           <br className="md:hidden" />
           <a


### PR DESCRIPTION
## 📌 변경 사항 요약

푸터의 `공식 인스타그램` 링크를 `FAQ`(/faq) 링크로 교체했습니다.

## 🔍 상세 내용

- 링크트리(`linktr.ee/dgu_caps`) 페이지 안에 이미 공식 인스타그램 링크가 포함되어 있어, 푸터에 별도의 `공식 인스타그램` 항목이 중복이었습니다.
- 해당 자리를 자주 찾는 `FAQ` 링크로 대체하여 푸터 동선을 개선했습니다.
- 아이콘도 인스타그램 아이콘 → 물음표 원형(FAQ) 아이콘으로 변경했으며, 기존 푸터 아이콘 스타일(`stroke="#ccc"`, `w-6 h-6` inline SVG)을 그대로 따랐습니다.
- 링크트리 / 문의하기 / 회칙 항목은 그대로 유지했습니다.

> 참고: 헤더 메뉴 재배치(집부-연혁-위키-블로그-장부)는 이번 PR 범위에서 제외했습니다. (요청상 푸터만 수정)

## 📸 스크린샷

| Before | After |
| --- | --- |
| 공식 인스타그램 (instagram.com/caps_dongguk) | FAQ (/faq) |

## ✅ 테스트 항목

- [ ] 푸터의 첫 항목이 `FAQ`로 표시되는지 확인
- [ ] `FAQ` 클릭 시 `/faq` 페이지로 이동하는지 확인
- [ ] 링크트리 / 문의하기 / 회칙 링크가 정상 동작하는지 확인
- [x] `vite build` 정상 통과

## 🔄 관련 이슈

-

## 🧩 기타 참고 사항

`vite build` 로컬 검증 완료. 기존 청크 크기 경고 외 신규 경고 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)