### PR TITLE
feat: 블로그 목록/상세 페이지 및 헤더 메뉴 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import WikiEditPage from "./pages/WikiEditPage.jsx";
 import AboutUs from "./pages/AboutUsPage.tsx";
 import CapsHistoryPage from "./pages/CapsHistoryPage.tsx";
 import FAQPage from "./pages/FAQPage.tsx";
+import BlogPage from "./pages/BlogPage.tsx";
+import BlogDetailPage from "./pages/BlogDetailPage.tsx";
 import LedgerBoardPage from "./pages/LedgerBoardPage.tsx";
 import LedgerDetailPage from "./pages/LedgerDetailPage.tsx";
 import LedgerEditPage from "./pages/LedgerEditPage.tsx";
@@ -62,6 +64,14 @@ const App: React.FC = () => {
     {
       path: "/faq",
       element: <FAQPage />,
+    },
+    {
+      path: "/blog",
+      element: <BlogPage />,
+    },
+    {
+      path: "/blog/:blogId",
+      element: <BlogDetailPage />,
     },
     {
       path: "/intro",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,6 +14,7 @@ import {
   User as UserIcon,
   FileText,
   AlertCircle,
+  Newspaper,
 } from "lucide-react";
 
 interface NavbarProps {
@@ -138,6 +139,13 @@ function Navbar({ isTransparent = false, transparentBackground = false }: Navbar
           >
             <span className="hidden md:inline">연혁</span>
             <HistoryIcon className="inline-block md:hidden" size={20} />
+          </Link>
+          <Link
+            to="/blog"
+            className={`flex items-center text-base font-semibold transition ${menuColor}`}
+          >
+            <span className="hidden md:inline">블로그</span>
+            <Newspaper className="inline-block md:hidden" size={20} />
           </Link>
           {isLoggedIn && user?.role !== "NEW_MEMBER" && (
             <Link

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import axios from "axios";
+import Navbar from "../components/NavBar";
+import Footer from "../components/MainPage/Footer";
+import { apiGet } from "../utils/Api";
+
+interface BlogDetail {
+  id: number;
+  title: string;
+  subtitle: string;
+  content: string;
+  category: string;
+  isPrivate: boolean;
+  writerGrade: number;
+  writerName: string;
+  createdAt: string;
+  fileUrls: string[];
+  imageUrls: string[];
+}
+
+const CATEGORY_LABEL: Record<string, string> = {
+  EVENTS: "행사",
+  ACADEMIC: "학술",
+  TECH: "기술",
+};
+
+function formatDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}.${m}.${day}`;
+}
+
+const BlogDetailPage: React.FC = () => {
+  const { blogId } = useParams();
+  const navigate = useNavigate();
+  const [post, setPost] = useState<BlogDetail | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [errorMsg, setErrorMsg] = useState<string>("");
+
+  useEffect(() => {
+    let ignore = false;
+    const fetchPost = async () => {
+      setLoading(true);
+      setErrorMsg("");
+      try {
+        const res = await apiGet(`/api/v1/blogs/${blogId}`);
+        if (ignore) return;
+        setPost(res.data?.data ?? null);
+      } catch (e) {
+        if (ignore) return;
+        console.error("블로그 상세 조회 실패:", e);
+        let msg = "게시물을 불러오지 못했습니다.";
+        if (axios.isAxiosError(e) && e.response) {
+          if (e.response.status === 403) msg = "비공개 처리된 게시물입니다.";
+          else if (e.response.status === 404) msg = "존재하지 않는 게시물입니다.";
+        }
+        setErrorMsg(msg);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    };
+    fetchPost();
+    return () => {
+      ignore = true;
+    };
+  }, [blogId]);
+
+  return (
+    <div className="bg-[#FAFAFA] min-h-screen">
+      <Navbar />
+      <div className="pt-20 max-w-3xl mx-auto px-4 pb-20">
+        <button
+          onClick={() => navigate("/blog")}
+          className="mt-6 mb-8 text-sm font-semibold text-gray-500 transition-colors hover:text-blue-600"
+        >
+          ← 목록으로
+        </button>
+
+        {loading ? (
+          <p className="text-center text-gray-500 py-20">로딩 중...</p>
+        ) : errorMsg ? (
+          <div className="text-center py-20">
+            <p className="mb-6 text-gray-500">{errorMsg}</p>
+            <button
+              onClick={() => navigate("/blog")}
+              className="rounded-full bg-[#007AEB] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#0079ebcc]"
+            >
+              블로그로 돌아가기
+            </button>
+          </div>
+        ) : post ? (
+          <article>
+            <span className="mb-4 inline-block rounded-full bg-blue-500 px-3 py-0.5 text-xs font-semibold text-white">
+              {CATEGORY_LABEL[post.category] ?? post.category}
+            </span>
+            <h1 className="mb-3 text-2xl md:text-3xl font-bold text-black">{post.title}</h1>
+            {post.subtitle && <p className="mb-4 text-lg text-gray-600">{post.subtitle}</p>}
+            <div className="mb-8 flex items-center gap-2 border-b border-gray-200 pb-6 text-sm text-gray-400">
+              <span>
+                {post.writerName}
+                {post.writerGrade ? ` · ${post.writerGrade}기` : ""}
+              </span>
+              <span>·</span>
+              <span>{formatDate(post.createdAt)}</span>
+            </div>
+
+            {post.imageUrls?.length > 0 && (
+              <div className="mb-8 flex flex-col gap-4">
+                {post.imageUrls.map((url, i) => (
+                  <img
+                    key={i}
+                    src={url}
+                    alt={`${post.title} 이미지 ${i + 1}`}
+                    className="w-full rounded-lg"
+                  />
+                ))}
+              </div>
+            )}
+
+            <div className="whitespace-pre-wrap leading-relaxed text-gray-800">{post.content}</div>
+
+            {post.fileUrls?.length > 0 && (
+              <div className="mt-10 border-t border-gray-200 pt-6">
+                <p className="mb-3 text-sm font-semibold text-gray-700">첨부파일</p>
+                <ul className="flex flex-col gap-2">
+                  {post.fileUrls.map((url, i) => (
+                    <li key={i}>
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="break-all text-sm text-blue-600 hover:underline"
+                      >
+                        {url.split("/").pop() || `첨부파일 ${i + 1}`}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </article>
+        ) : null}
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default BlogDetailPage;

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Navbar from "../components/NavBar";
+import Footer from "../components/MainPage/Footer";
+import { apiGet } from "../utils/Api";
+
+interface BlogListItem {
+  id: number;
+  title: string;
+  subtitle: string;
+  thumbnailUrl: string | null;
+  category: string;
+  isPrivate: boolean;
+  writerGrade: number;
+  writerName: string;
+  createdAt: string;
+}
+
+const CATEGORIES = [
+  { key: "ALL", label: "전체" },
+  { key: "EVENTS", label: "행사" },
+  { key: "ACADEMIC", label: "학술" },
+  { key: "TECH", label: "기술" },
+] as const;
+
+const CATEGORY_LABEL: Record<string, string> = {
+  EVENTS: "행사",
+  ACADEMIC: "학술",
+  TECH: "기술",
+};
+
+function formatDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}.${m}.${day}`;
+}
+
+const BlogPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [posts, setPosts] = useState<BlogListItem[]>([]);
+  const [category, setCategory] = useState<string>("ALL");
+  const [page, setPage] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(1);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+
+  useEffect(() => {
+    let ignore = false;
+    const fetchPosts = async () => {
+      setLoading(true);
+      setError(false);
+      try {
+        const query = new URLSearchParams();
+        query.set("page", String(page));
+        if (category !== "ALL") query.set("category", category);
+        const res = await apiGet(`/api/v1/blogs?${query.toString()}`);
+        if (ignore) return;
+        const body = res.data?.data;
+        setPosts(body?.content ?? []);
+        setTotalPages(body?.totalPages && body.totalPages > 0 ? body.totalPages : 1);
+      } catch (e) {
+        if (ignore) return;
+        console.error("블로그 목록 조회 실패:", e);
+        setError(true);
+        setPosts([]);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    };
+    fetchPosts();
+    return () => {
+      ignore = true;
+    };
+  }, [category, page]);
+
+  const handleCategory = (key: string) => {
+    setCategory(key);
+    setPage(1);
+  };
+
+  return (
+    <div className="bg-[#FAFAFA] min-h-screen">
+      <Navbar />
+      <div className="pt-20 max-w-5xl mx-auto px-4 pb-20">
+        {/* 타이틀 */}
+        <div className="pt-8 pb-6 text-center">
+          <h1 className="text-3xl md:text-4xl font-bold text-black mb-3">블로그</h1>
+          <p className="text-gray-500">CAPS의 활동과 소식을 전합니다.</p>
+        </div>
+
+        {/* 카테고리 필터 */}
+        <div className="flex flex-wrap justify-center gap-2 mb-10">
+          {CATEGORIES.map((c) => {
+            const active = category === c.key;
+            return (
+              <button
+                key={c.key}
+                onClick={() => handleCategory(c.key)}
+                className={`whitespace-nowrap px-4 md:px-5 py-2 rounded-full text-sm md:text-base font-semibold transition-colors duration-200 border ${
+                  active
+                    ? "bg-blue-500 text-white border-blue-500 shadow-sm"
+                    : "bg-white text-blue-600 border-blue-300 hover:bg-blue-50"
+                }`}
+              >
+                {c.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* 목록 */}
+        {loading ? (
+          <p className="text-center text-gray-500 py-20">로딩 중...</p>
+        ) : error ? (
+          <p className="text-center text-gray-500 py-20">
+            게시물을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+          </p>
+        ) : posts.length === 0 ? (
+          <p className="text-center text-gray-400 py-20">아직 등록된 게시물이 없습니다.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-8">
+            {posts.map((post) => (
+              <article
+                key={post.id}
+                onClick={() => navigate(`/blog/${post.id}`)}
+                className="group cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:shadow-md"
+              >
+                <div className="h-44 w-full overflow-hidden bg-gray-100">
+                  {post.thumbnailUrl ? (
+                    <img
+                      src={post.thumbnailUrl}
+                      alt={post.title}
+                      className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-sm tracking-widest text-gray-300">
+                      CAPS
+                    </div>
+                  )}
+                </div>
+                <div className="p-4">
+                  <span className="mb-2 inline-block rounded-full bg-blue-500 px-3 py-0.5 text-xs font-semibold text-white">
+                    {CATEGORY_LABEL[post.category] ?? post.category}
+                  </span>
+                  <h3 className="truncate text-base font-semibold text-black">{post.title}</h3>
+                  {post.subtitle && (
+                    <p className="mt-1 line-clamp-2 text-sm text-gray-600">{post.subtitle}</p>
+                  )}
+                  <div className="mt-3 flex items-center justify-between text-xs text-gray-400">
+                    <span className="truncate">
+                      {post.writerName}
+                      {post.writerGrade ? ` · ${post.writerGrade}기` : ""}
+                    </span>
+                    <span>{formatDate(post.createdAt)}</span>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+        {/* 페이지네이션 */}
+        {!loading && !error && totalPages > 1 && (
+          <div className="mt-12 flex items-center justify-center gap-4">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+              className="text-sm font-semibold text-gray-700 transition-colors hover:text-gray-900 disabled:text-gray-300"
+            >
+              이전
+            </button>
+            <div className="flex items-center gap-3">
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPage(p)}
+                  className={`text-sm font-semibold transition-colors ${
+                    p === page ? "text-blue-500" : "text-gray-500 hover:text-gray-800"
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages}
+              className="text-sm font-semibold text-gray-700 transition-colors hover:text-gray-900 disabled:text-gray-300"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default BlogPage;


### PR DESCRIPTION
## 📌 변경 사항 요약

`/blog` 블로그 목록 페이지와 `/blog/:blogId` 상세 페이지를 추가하고, 헤더 네비게이션에 `블로그` 메뉴를 추가했습니다. 기존 페이지 템플릿 디자인을 그대로 따랐습니다.

## 🔍 상세 내용

- **블로그 목록 (`/blog`, `src/pages/BlogPage.tsx`)**
  - 카테고리 필터: 전체 / 행사(EVENTS) / 학술(ACADEMIC) / 기술(TECH) — `AboutUsPage`의 필터 pill 스타일 재사용
  - 카드 그리드(썸네일 + 카테고리 뱃지 + 제목 + 부제 + 작성자·날짜) — `GalleryList` 카드 스타일 기반
  - 페이지네이션(12개/페이지), 로딩 / 빈 목록 / 에러 상태 처리
  - `GET /api/v1/blogs?page=&category=` 연동 (공개 API — `apiGet` 사용)
- **블로그 상세 (`/blog/:blogId`, `src/pages/BlogDetailPage.tsx`)**
  - 제목/부제/카테고리/작성자/작성일/본문/이미지/첨부파일 표시
  - 비공개(403) / 존재하지 않음(404) 에러 메시지 및 목록 복귀 버튼
  - `GET /api/v1/blogs/{blogId}` 연동
- **헤더 (`src/components/NavBar.tsx`)**: `연혁` 다음에 `블로그`(`/blog`) 메뉴 추가. 모바일은 `lucide-react`의 `Newspaper` 아이콘, `${menuColor}` + `hidden md:inline` 컨벤션 준수
- **라우팅 (`src/App.tsx`)**: `/blog`, `/blog/:blogId` 공개 라우트 추가(catch-all 위)

## 🎨 템플릿 준수
- 페이지 쉘: `bg-[#FAFAFA] min-h-screen` + 자체 `<Navbar/>`/`<Footer/>` 렌더 + `pt-20`로 고정 네비 회피 (`CapsHistoryPage`/`AboutUsPage`와 동일)
- 브랜드 컬러: 액센트 `blue-500`, 버튼 `#007AEB`

## 📸 스크린샷

현재 백엔드에 게시물이 0개라 목록은 "아직 등록된 게시물이 없습니다." 빈 상태로 표시됩니다. (API `GET /api/v1/blogs` 응답: `data.content: []`)

## ✅ 테스트 항목

- [x] `vite build` 정상 통과
- [ ] `/blog` 접근 시 헤더/푸터/타이틀/카테고리 필터 렌더 확인
- [ ] 게시물 등록 후 카드 그리드·페이지네이션·상세 이동 동작 확인
- [ ] 헤더 `블로그` 메뉴 클릭 시 `/blog` 이동 확인 (데스크톱/모바일)

## 🔄 관련 이슈

-

## 🧩 기타 참고 사항

- 상세 본문(`content`)은 XSS 방지를 위해 **plain text(`whitespace-pre-wrap`)** 로 렌더합니다. 백엔드가 HTML/마크다운을 저장하는 형식이라면 sanitizer(DOMPurify 등) 추가 후 리치 렌더링으로 전환이 필요합니다. (현재 게시물이 없어 실제 포맷 미확인)
- 카테고리 라벨 매핑: EVENTS=행사, ACADEMIC=학술, TECH=기술
- 이번 PR은 헤더에 `블로그`만 **추가**했고, 앞서 논의된 헤더 전체 재배치(집부-연혁-위키-블로그-장부)는 포함하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)