### PR TITLE
feat: 블로그 열람을 로그인 전용으로 전환

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,11 @@ const App: React.FC = () => {
     },
     {
       path: "/blog",
-      element: <BlogPage />,
+      element: (
+        <ProtectedRoute>
+          <BlogPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "/blog/edit",
@@ -80,7 +84,11 @@ const App: React.FC = () => {
     },
     {
       path: "/blog/:blogId",
-      element: <BlogDetailPage />,
+      element: (
+        <ProtectedRoute>
+          <BlogDetailPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "/blog/:blogId/edit",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -140,13 +140,15 @@ function Navbar({ isTransparent = false, transparentBackground = false }: Navbar
             <span className="hidden md:inline">연혁</span>
             <HistoryIcon className="inline-block md:hidden" size={20} />
           </Link>
-          <Link
-            to="/blog"
-            className={`flex items-center text-base font-semibold transition ${menuColor}`}
-          >
-            <span className="hidden md:inline">블로그</span>
-            <Newspaper className="inline-block md:hidden" size={20} />
-          </Link>
+          {isLoggedIn && (
+            <Link
+              to="/blog"
+              className={`flex items-center text-base font-semibold transition ${menuColor}`}
+            >
+              <span className="hidden md:inline">블로그</span>
+              <Newspaper className="inline-block md:hidden" size={20} />
+            </Link>
+          )}
           {isLoggedIn && user?.role !== "NEW_MEMBER" && (
             <Link
               to="/ledger"

--- a/src/utils/blogFiles.ts
+++ b/src/utils/blogFiles.ts
@@ -19,10 +19,11 @@ function pickDownloadUrl(response: unknown, fallback: string): string {
 /**
  * 저장된 key 를 실제로 열 수 있는 URL 로 바꾼다.
  *
- * 공개 엔드포인트(GET /api/v1/files/blog/presigned-url)는 비로그인도 호출할 수 있지만
- * 서버가 blog_file(첨부파일) 키만 허용한다. 본문 이미지와 썸네일은 각각 blog_image /
- * blog_post 에 있어 403 이 나므로, 그때만 로그인 회원용 범용 엔드포인트로 다시 시도한다.
- * (즉 현재는 비로그인 사용자에게 이미지·썸네일이 보이지 않는다 — 서버 수정 필요)
+ * 블로그 전용 엔드포인트(GET /api/v1/files/blog/presigned-url)는 서버가 blog_file(첨부파일)
+ * 키만 허용한다. 본문 이미지와 썸네일은 각각 blog_image / blog_post 에 있어 403 이 나므로,
+ * 그때만 회원용 범용 엔드포인트로 다시 시도한다.
+ * 블로그 열람 자체가 로그인 전용이라 대부분 이 폴백으로 해결되지만,
+ * 범용 엔드포인트는 MEMBER 이상만 허용하므로 NEW_MEMBER 는 이미지를 볼 수 없다.
  */
 export async function resolveBlogFileUrl(value: string): Promise<string> {
   if (isAbsoluteUrl(value)) return value;


### PR DESCRIPTION
## 📌 변경 사항 요약

블로그 열람을 **로그인 전용**으로 바꿉니다. 위키(#106)와 동일한 정책입니다.

## 🔍 상세 내용

기존 상태가 어정쩡했습니다. 백엔드 `BlogService` 기준:
- **비공개 글(`isPrivate=true`)**: 목록에서 제외(`findByIsPrivateFalse`), 상세는 `validatePrivateAccess`로 403 → 이미 완전 차단
- **공개 글(`isPrivate=false`)**: 목록·상세가 `permitAll`이고 **본문을 가리는 로직이 없음** → 비로그인도 제목·부제·본문 전체를 읽을 수 있었음

반면 이미지·썸네일은 공개 presign 엔드포인트가 `blog_file`(첨부파일) 키만 허용해서 403이 났습니다. 결과적으로 **비로그인에게 본문은 보이는데 이미지만 안 보이는** 상태였습니다.

의도가 "비로그인은 블로그를 볼 수 없다"이므로, 열람 자체를 로그인 전용으로 통일합니다.

- `/blog`, `/blog/:blogId` 를 `ProtectedRoute` 로 감쌈 (등록/수정 라우트는 이미 적용돼 있었음)
- 헤더 `블로그` 메뉴를 `isLoggedIn` 일 때만 노출

> 위키는 라우트만 보호하고 헤더 링크는 항상 노출(클릭 시 alert 후 홈 이동)합니다. 블로그는 메뉴 자체를 감춰 한 단계 더 깔끔하게 했습니다. 위키와 완전히 동일하게 맞추길 원하시면 메뉴 조건만 빼면 됩니다.

## 🧩 기타 참고 사항

- 이제 열람자는 모두 로그인 상태이므로, 이미지·썸네일은 `blogFiles.ts` 의 폴백(회원용 범용 presign)으로 정상 표시됩니다.
- 다만 범용 presign 엔드포인트는 `MEMBER` 이상만 허용하므로 **`NEW_MEMBER` 는 이미지를 볼 수 없습니다.** 필요하면 백엔드에서 블로그 presign 화이트리스트에 `BlogImage`/`BlogPost.thumbnailUrl` 을 추가하는 쪽이 근본 해결입니다.
- 백엔드는 변경 없이 프론트에서만 차단합니다. 서버 API 자체는 여전히 공개글을 `permitAll` 로 응답하므로, 엄격히 막으려면 서버 정책도 함께 조정이 필요합니다.

## ✅ 테스트 항목

- [x] `vite build` 통과
- [x] 블로그 관련 파일 `tsc --noEmit` 통과
- [ ] 로그아웃 상태에서 헤더에 `블로그` 미노출 확인
- [ ] 로그아웃 상태에서 `/blog` 직접 접근 시 홈으로 리다이렉트 확인
- [ ] 로그인 후 목록·상세·이미지 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)