### PR TITLE
chore: develop → main (블로그 열람 로그인 전용 전환)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,11 @@ const App: React.FC = () => {
     },
     {
       path: "/blog",
-      element: <BlogPage />,
+      element: (
+        <ProtectedRoute>
+          <BlogPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "/blog/edit",
@@ -80,7 +84,11 @@ const App: React.FC = () => {
     },
     {
       path: "/blog/:blogId",
-      element: <BlogDetailPage />,
+      element: (
+        <ProtectedRoute>
+          <BlogDetailPage />
+        </ProtectedRoute>
+      ),
     },
     {
       path: "/blog/:blogId/edit",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -140,13 +140,15 @@ function Navbar({ isTransparent = false, transparentBackground = false }: Navbar
             <span className="hidden md:inline">연혁</span>
             <HistoryIcon className="inline-block md:hidden" size={20} />
           </Link>
-          <Link
-            to="/blog"
-            className={`flex items-center text-base font-semibold transition ${menuColor}`}
-          >
-            <span className="hidden md:inline">블로그</span>
-            <Newspaper className="inline-block md:hidden" size={20} />
-          </Link>
+          {isLoggedIn && (
+            <Link
+              to="/blog"
+              className={`flex items-center text-base font-semibold transition ${menuColor}`}
+            >
+              <span className="hidden md:inline">블로그</span>
+              <Newspaper className="inline-block md:hidden" size={20} />
+            </Link>
+          )}
           {isLoggedIn && user?.role !== "NEW_MEMBER" && (
             <Link
               to="/ledger"

--- a/src/utils/blogFiles.ts
+++ b/src/utils/blogFiles.ts
@@ -19,10 +19,11 @@ function pickDownloadUrl(response: unknown, fallback: string): string {
 /**
  * 저장된 key 를 실제로 열 수 있는 URL 로 바꾼다.
  *
- * 공개 엔드포인트(GET /api/v1/files/blog/presigned-url)는 비로그인도 호출할 수 있지만
- * 서버가 blog_file(첨부파일) 키만 허용한다. 본문 이미지와 썸네일은 각각 blog_image /
- * blog_post 에 있어 403 이 나므로, 그때만 로그인 회원용 범용 엔드포인트로 다시 시도한다.
- * (즉 현재는 비로그인 사용자에게 이미지·썸네일이 보이지 않는다 — 서버 수정 필요)
+ * 블로그 전용 엔드포인트(GET /api/v1/files/blog/presigned-url)는 서버가 blog_file(첨부파일)
+ * 키만 허용한다. 본문 이미지와 썸네일은 각각 blog_image / blog_post 에 있어 403 이 나므로,
+ * 그때만 회원용 범용 엔드포인트로 다시 시도한다.
+ * 블로그 열람 자체가 로그인 전용이라 대부분 이 폴백으로 해결되지만,
+ * 범용 엔드포인트는 MEMBER 이상만 허용하므로 NEW_MEMBER 는 이미지를 볼 수 없다.
  */
 export async function resolveBlogFileUrl(value: string): Promise<string> {
   if (isAbsoluteUrl(value)) return value;


### PR DESCRIPTION
## 📌 변경 사항 요약

블로그 열람을 로그인 전용으로 전환한 변경(#113)을 프로덕션에 배포합니다.

## 🔍 상세 내용

- `/blog`, `/blog/:blogId` 를 `ProtectedRoute` 로 보호
- 헤더 `블로그` 메뉴를 로그인 시에만 노출
- 위키(#106)와 동일한 정책

기존에는 공개 글의 본문이 비로그인에게도 읽혔고 이미지만 403으로 안 보이는 어정쩡한 상태였습니다.

## 🧩 기타

- 프론트에서만 차단합니다. 서버는 여전히 공개글을 `permitAll` 로 응답하므로 엄격한 차단은 서버 정책 조정이 필요합니다.
- 머지 시 `s3-deploy.yml`(AWS Deploy)로 S3 sync + CloudFront 무효화가 트리거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)