### PR TITLE
chore: 헤더에서 블로그 메뉴 임시 숨김

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,7 +14,6 @@ import {
   User as UserIcon,
   FileText,
   AlertCircle,
-  Newspaper,
 } from "lucide-react";
 
 interface NavbarProps {
@@ -140,15 +139,7 @@ function Navbar({ isTransparent = false, transparentBackground = false }: Navbar
             <span className="hidden md:inline">연혁</span>
             <HistoryIcon className="inline-block md:hidden" size={20} />
           </Link>
-          {isLoggedIn && (
-            <Link
-              to="/blog"
-              className={`flex items-center text-base font-semibold transition ${menuColor}`}
-            >
-              <span className="hidden md:inline">블로그</span>
-              <Newspaper className="inline-block md:hidden" size={20} />
-            </Link>
-          )}
+          {/* 블로그 메뉴는 디자인 확정 전까지 숨김 (/blog 라우트는 그대로 동작) */}
           {isLoggedIn && user?.role !== "NEW_MEMBER" && (
             <Link
               to="/ledger"


### PR DESCRIPTION
## 📌 변경 사항 요약

블로그 디자인이 확정될 때까지 헤더의 `블로그` 메뉴를 숨깁니다.

## 🔍 상세 내용

- `NavBar.tsx` 에서 `블로그` `<Link>` 제거 (사용하지 않게 된 `Newspaper` 아이콘 import 도 정리)
- **라우트는 그대로 유지**: `/blog`, `/blog/:blogId`, `/blog/edit`, `/blog/:blogId/edit` 모두 동작합니다. 주소로 직접 들어가면 계속 확인·작성 가능합니다.
- 로그인 전용 보호(`ProtectedRoute`)도 그대로입니다.

디자인 반영이 끝나면 `<Link>` 만 되돌리면 됩니다.

## ✅ 테스트 항목

- [x] `vite build` 통과
- [ ] 헤더에 `블로그` 미노출 확인
- [ ] `/blog` 직접 접근 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)