### PR TITLE
chore: develop → main (헤더 블로그 메뉴 임시 숨김)

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,7 +14,6 @@ import {
   User as UserIcon,
   FileText,
   AlertCircle,
-  Newspaper,
 } from "lucide-react";
 
 interface NavbarProps {
@@ -140,15 +139,7 @@ function Navbar({ isTransparent = false, transparentBackground = false }: Navbar
             <span className="hidden md:inline">연혁</span>
             <HistoryIcon className="inline-block md:hidden" size={20} />
           </Link>
-          {isLoggedIn && (
-            <Link
-              to="/blog"
-              className={`flex items-center text-base font-semibold transition ${menuColor}`}
-            >
-              <span className="hidden md:inline">블로그</span>
-              <Newspaper className="inline-block md:hidden" size={20} />
-            </Link>
-          )}
+          {/* 블로그 메뉴는 디자인 확정 전까지 숨김 (/blog 라우트는 그대로 동작) */}
           {isLoggedIn && user?.role !== "NEW_MEMBER" && (
             <Link
               to="/ledger"


### PR DESCRIPTION
## 📌 변경 사항 요약

헤더의 `블로그` 메뉴를 임시로 숨기는 변경(#115)을 배포합니다.

블로그 디자인이 확정될 때까지 노출을 보류합니다. 라우트(`/blog`, `/blog/:blogId`, `/blog/edit`)와 등록/수정/삭제 기능은 그대로 동작하므로 주소로 직접 접근해 확인할 수 있습니다.

머지 시 `s3-deploy.yml`(AWS Deploy)로 S3 sync + CloudFront 무효화가 트리거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)