### PR TITLE
release: 블로그 디자인 반영 배포 (develop→main)

### DIFF
--- a/src/components/Blog/categories.tsx
+++ b/src/components/Blog/categories.tsx
@@ -1,0 +1,35 @@
+import { Calendar, BookOpen, Code2, type LucideIcon } from "lucide-react";
+
+/**
+ * 블로그 카테고리 메타 (라벨·아이콘) 정본.
+ * 목록 필터 / 카드 배지 / 상세 배지 / 작성폼 선택칩이 모두 이 정의를 공유한다.
+ * 백엔드 enum(GetBlogsCategory·BlogListResponseCategory·CreateOrModifyBlogRequestCategory)은
+ * 값이 모두 EVENTS/ACADEMIC/TECH 로 동일하므로 문자열 키로 좁혀 쓴다.
+ */
+export type BlogCategoryKey = "EVENTS" | "ACADEMIC" | "TECH";
+
+export interface BlogCategoryMeta {
+  key: BlogCategoryKey;
+  /** 배지·필터에 노출하는 영문 라벨 (디자인 기준) */
+  label: string;
+  /** 한글 라벨 */
+  korean: string;
+  /** 작성폼 선택칩의 보조 설명 */
+  hint: string;
+  Icon: LucideIcon;
+}
+
+export const BLOG_CATEGORIES: BlogCategoryMeta[] = [
+  { key: "EVENTS", label: "Events", korean: "행사", hint: "행사 기록", Icon: Calendar },
+  { key: "ACADEMIC", label: "Academic", korean: "학술", hint: "학술 아카이빙", Icon: BookOpen },
+  { key: "TECH", label: "Tech", korean: "기술", hint: "기술 인사이트", Icon: Code2 },
+];
+
+export const BLOG_CATEGORY_MAP: Record<string, BlogCategoryMeta> = Object.fromEntries(
+  BLOG_CATEGORIES.map((c) => [c.key, c])
+);
+
+/** 카테고리 키를 디자인 라벨(영문)로. 알 수 없는 값은 그대로 돌려준다. */
+export function blogCategoryLabel(key?: string): string {
+  return (key && BLOG_CATEGORY_MAP[key]?.label) || key || "";
+}

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -3,9 +3,11 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { match } from "ts-pattern";
 import axios from "axios";
+import { ChevronLeft, Paperclip, Lock } from "lucide-react";
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
 import BlogImage from "../components/Blog/BlogImage";
+import { BLOG_CATEGORY_MAP, blogCategoryLabel } from "../components/Blog/categories";
 import { useAuth } from "../hooks/useAuth";
 import { resolveBlogFileUrl, blogFileName } from "../utils/blogFiles";
 import {
@@ -15,12 +17,6 @@ import {
   BlogDetailResponse,
 } from "../api/generated/capsApi";
 
-const CATEGORY_LABEL: Record<string, string> = {
-  EVENTS: "행사",
-  ACADEMIC: "학술",
-  TECH: "기술",
-};
-
 function formatDate(iso?: string): string {
   if (!iso) return "";
   const d = new Date(iso);
@@ -28,7 +24,7 @@ function formatDate(iso?: string): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
-  return `${y}.${m}.${day}`;
+  return `${y}. ${m}. ${day}`;
 }
 
 function errorMessageOf(error: unknown): string {
@@ -53,6 +49,7 @@ const BlogDetailPage: React.FC = () => {
   const [loadingFile, setLoadingFile] = useState<string | null>(null);
 
   const post = data?.data as BlogDetailResponse | undefined;
+  const cat = post?.category ? BLOG_CATEGORY_MAP[post.category] : undefined;
 
   // 첨부는 저장된 값이 S3 key 일 수 있어 클릭 시점에 열 수 있는 주소로 바꿔서 내려받는다
   const handleFileClick = async (fileUrl: string, e: React.MouseEvent) => {
@@ -95,12 +92,13 @@ const BlogDetailPage: React.FC = () => {
   return (
     <div className="bg-[#FAFAFA] min-h-screen">
       <Navbar />
-      <div className="pt-20 max-w-3xl mx-auto px-4 pb-20">
+      <div className="pt-20 max-w-3xl mx-auto px-4 md:px-6 pb-24">
         <button
           onClick={() => navigate("/blog")}
-          className="mt-6 mb-8 text-sm font-semibold text-gray-500 transition-colors hover:text-blue-600"
+          className="mt-8 mb-8 inline-flex items-center gap-1 text-sm font-semibold text-gray-500 transition-colors hover:text-[#007AEB]"
         >
-          ← 목록으로
+          <ChevronLeft className="h-4 w-4" />
+          목록으로
         </button>
 
         {isLoading ? (
@@ -110,30 +108,38 @@ const BlogDetailPage: React.FC = () => {
             <p className="mb-6 text-gray-500">{errorMessageOf(error)}</p>
             <button
               onClick={() => navigate("/blog")}
-              className="rounded-full bg-[#007AEB] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#0079ebcc]"
+              className="rounded-full bg-[#007AEB] px-6 py-3 text-sm font-bold text-white transition-colors hover:bg-[#0069cc]"
             >
               블로그로 돌아가기
             </button>
           </div>
         ) : post ? (
           <article>
-            <div className="mb-4 flex items-start justify-between gap-4">
-              <span className="inline-block rounded-full bg-blue-500 px-3 py-0.5 text-xs font-semibold text-white">
-                {CATEGORY_LABEL[post.category ?? ""] ?? post.category}
-              </span>
+            {/* 카테고리 + 수정/삭제 */}
+            <div className="mb-5 flex items-center justify-between gap-4">
+              {cat ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-[#007AEB] px-3.5 py-1 text-sm font-bold text-white">
+                  <cat.Icon className="h-4 w-4" strokeWidth={2} />
+                  {cat.label}
+                </span>
+              ) : (
+                <span className="inline-block rounded-full bg-[#007AEB] px-3.5 py-1 text-sm font-bold text-white">
+                  {blogCategoryLabel(post.category)}
+                </span>
+              )}
               {match(user?.role)
                 .with("ADMIN", "COUNCIL", "PRESIDENT", () => (
-                  <div className="flex shrink-0 items-center gap-3">
+                  <div className="flex shrink-0 items-center gap-2">
                     <button
                       onClick={() => navigate(`/blog/${id}/edit`)}
-                      className="text-sm font-semibold text-gray-600 transition-colors hover:text-blue-600"
+                      className="rounded-full bg-[#007AEB] px-5 py-2 text-sm font-bold text-white transition-colors hover:bg-[#0069cc]"
                     >
                       수정
                     </button>
                     <button
                       onClick={handleDelete}
                       disabled={isDeleting}
-                      className="text-sm font-semibold text-gray-600 transition-colors hover:text-red-600 disabled:text-gray-300"
+                      className="rounded-full border border-gray-300 px-5 py-2 text-sm font-bold text-gray-600 transition-colors hover:border-red-400 hover:text-red-500 disabled:opacity-50"
                     >
                       {isDeleting ? "삭제 중..." : "삭제"}
                     </button>
@@ -142,57 +148,77 @@ const BlogDetailPage: React.FC = () => {
                 .otherwise(() => null)}
             </div>
 
-            <h1 className="mb-3 text-2xl md:text-3xl font-bold text-black">{post.title}</h1>
-            {post.subtitle && <p className="mb-4 text-lg text-gray-600">{post.subtitle}</p>}
-            <div className="mb-8 flex items-center gap-2 border-b border-gray-200 pb-6 text-sm text-gray-400">
-              <span>
+            <h1 className="text-3xl md:text-4xl font-extrabold leading-snug text-black">
+              {post.title}
+            </h1>
+            {post.subtitle && (
+              <p className="mt-3 text-lg font-medium text-[#374151]">{post.subtitle}</p>
+            )}
+
+            <div className="mt-6 flex flex-wrap items-center gap-2 border-b border-gray-200 pb-6 text-sm text-gray-400">
+              <span className="font-medium text-gray-500">
+                {post.writerGrade ? `${post.writerGrade}기 ` : ""}
                 {post.writerName}
-                {post.writerGrade ? ` · ${post.writerGrade}기` : ""}
               </span>
               <span>·</span>
               <span>{formatDate(post.createdAt)}</span>
               {post.isPrivate && (
-                <span className="ml-2 rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600">
+                <span className="ml-1 inline-flex items-center gap-1 rounded-full bg-gray-200 px-2.5 py-0.5 text-xs font-semibold text-gray-600">
+                  <Lock className="h-3 w-3" strokeWidth={2.2} />
                   비공개
                 </span>
               )}
             </div>
 
             {post.imageUrls && post.imageUrls.length > 0 && (
-              <div className="mb-8 flex flex-col gap-4">
+              <div className="mt-8 flex flex-col gap-4">
                 {post.imageUrls.map((url, i) => (
                   <BlogImage
                     key={i}
                     src={url}
                     alt={`${post.title} 이미지 ${i + 1}`}
-                    className="w-full rounded-lg"
+                    className="w-full rounded-xl"
                   />
                 ))}
               </div>
             )}
 
-            <div className="whitespace-pre-wrap leading-relaxed text-gray-800">{post.content}</div>
+            <div className="mt-8 whitespace-pre-wrap text-[15px] leading-8 text-gray-800">
+              {post.content}
+            </div>
 
             {post.fileUrls && post.fileUrls.length > 0 && (
               <div className="mt-10 border-t border-gray-200 pt-6">
-                <p className="mb-3 text-sm font-semibold text-gray-700">첨부파일</p>
+                <p className="mb-3 text-sm font-bold text-gray-700">첨부파일</p>
                 <ul className="flex flex-col gap-2">
                   {post.fileUrls.map((url, i) => (
                     <li key={i}>
                       <a
                         href="#"
                         onClick={(e) => handleFileClick(url, e)}
-                        className="break-all text-sm text-blue-600 hover:underline"
+                        className="inline-flex max-w-full items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 transition-colors hover:border-[#007AEB] hover:text-[#007AEB]"
                       >
-                        {loadingFile === url
-                          ? "불러오는 중..."
-                          : blogFileName(url) || `첨부파일 ${i + 1}`}
+                        <Paperclip className="h-4 w-4 shrink-0" strokeWidth={2} />
+                        <span className="truncate">
+                          {loadingFile === url
+                            ? "불러오는 중..."
+                            : blogFileName(url) || `첨부파일 ${i + 1}`}
+                        </span>
                       </a>
                     </li>
                   ))}
                 </ul>
               </div>
             )}
+
+            <div className="mt-12 flex justify-center">
+              <button
+                onClick={() => navigate("/blog")}
+                className="rounded-full bg-[#007AEB] px-8 py-3 text-sm font-bold text-white transition-colors hover:bg-[#0069cc]"
+              >
+                목록
+              </button>
+            </div>
           </article>
         ) : null}
       </div>

--- a/src/pages/BlogEditPage.tsx
+++ b/src/pages/BlogEditPage.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { Lock, Trash2, Paperclip, ImagePlus } from "lucide-react";
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
+import { BLOG_CATEGORIES, BLOG_CATEGORY_MAP } from "../components/Blog/categories";
 import { useAuth } from "../hooks/useAuth";
 import { uploadFileToS3, uploadMultipleFilesToS3 } from "../utils/s3Upload";
 import { blogFileName } from "../utils/blogFiles";
@@ -19,11 +21,8 @@ import {
 
 const WRITE_ROLES = ["ADMIN", "COUNCIL", "PRESIDENT"];
 
-const CATEGORY_OPTIONS = [
-  { key: CreateOrModifyBlogRequestCategory.EVENTS, label: "행사" },
-  { key: CreateOrModifyBlogRequestCategory.ACADEMIC, label: "학술" },
-  { key: CreateOrModifyBlogRequestCategory.TECH, label: "기술" },
-];
+const TITLE_MAX = 50;
+const SUBTITLE_MAX = 50;
 
 /** 업로드 대기 중인 파일 (선택 시점엔 올리지 않고 저장할 때 한 번에 올린다) */
 interface PendingFile {
@@ -59,6 +58,18 @@ const BlogEditPage: React.FC = () => {
   const { mutateAsync: modifyBlog } = useModifyBlog();
 
   const canWrite = WRITE_ROLES.includes(user?.role ?? "");
+
+  // 새로 고른 썸네일 미리보기 (URL 은 언마운트/교체 시 해제한다)
+  const thumbnailPreview = useMemo(
+    () => (thumbnail ? URL.createObjectURL(thumbnail) : null),
+    [thumbnail]
+  );
+  useEffect(
+    () => () => {
+      if (thumbnailPreview) URL.revokeObjectURL(thumbnailPreview);
+    },
+    [thumbnailPreview]
+  );
 
   // 로그인/권한이 없으면 되돌려보낸다
   useEffect(() => {
@@ -166,171 +177,327 @@ const BlogEditPage: React.FC = () => {
     }
   };
 
+  const previewCat = BLOG_CATEGORY_MAP[category];
+  const totalImages = existingImageUrls.length + images.length;
+
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex min-h-screen flex-col bg-[#FAFAFA]">
       <Navbar />
-      <main className="flex-1 mt-20">
-        <form onSubmit={handleSubmit} className="px-4 py-10 mx-auto space-y-6 max-w-4xl">
-          <div className="pb-4 mb-2 border-b border-gray-200">
+      <main className="flex-1 pt-20">
+        <form
+          onSubmit={handleSubmit}
+          className="mx-auto max-w-5xl px-4 md:px-6 py-10 space-y-6"
+        >
+          {/* 헤더: 제목 + 비공개 토글 + 취소/발행 */}
+          <div className="flex flex-col gap-4 border-b border-gray-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
+            <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-black">블로그</h1>
+            <div className="flex flex-wrap items-center gap-2.5">
+              <button
+                type="button"
+                onClick={() => setIsPrivate((v) => !v)}
+                aria-pressed={isPrivate}
+                className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold transition-colors ${
+                  isPrivate
+                    ? "border-[#007AEB] bg-[#007AEB]/10 text-[#007AEB]"
+                    : "border-gray-300 bg-white text-gray-500"
+                }`}
+              >
+                <Lock className="h-4 w-4" strokeWidth={2.2} />
+                비공개
+                <span
+                  className={`relative h-5 w-9 rounded-full transition-colors ${
+                    isPrivate ? "bg-[#007AEB]" : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all ${
+                      isPrivate ? "left-[18px]" : "left-0.5"
+                    }`}
+                  />
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate(isEdit ? `/blog/${id}` : "/blog")}
+                className="rounded-full border border-gray-300 px-6 py-2.5 text-sm font-bold text-gray-600 transition-colors hover:text-gray-900"
+              >
+                취소
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="rounded-full bg-[#007AEB] px-7 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#0069cc] disabled:bg-gray-300"
+              >
+                {submitting ? "저장 중..." : isEdit ? "수정" : "발행"}
+              </button>
+            </div>
+          </div>
+
+          {/* 제목 */}
+          <div className="relative">
             <input
               type="text"
               value={title}
+              maxLength={TITLE_MAX}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="제목을 입력하세요"
-              className="w-full text-xl font-extrabold placeholder-gray-400 text-black bg-transparent md:text-2xl focus:outline-none"
+              placeholder="제목을 입력하세요."
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3.5 pr-16 text-lg font-bold text-black placeholder-gray-400 focus:border-[#007AEB] focus:outline-none focus:ring-2 focus:ring-[#007AEB]/20"
             />
+            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-gray-400">
+              {title.length}/{TITLE_MAX}
+            </span>
           </div>
 
-          <input
-            type="text"
-            value={subtitle}
-            onChange={(e) => setSubtitle(e.target.value)}
-            placeholder="부제목 (선택)"
-            className="w-full px-4 py-3 text-sm border border-gray-200 rounded-[15px] focus:outline-none focus:ring-2 focus:ring-[#007AEB] focus:border-transparent"
-          />
-
-          {/* 카테고리 / 공개여부 */}
-          <div className="flex flex-wrap items-center gap-3">
-            {CATEGORY_OPTIONS.map((option) => (
-              <button
-                key={option.key}
-                type="button"
-                onClick={() => setCategory(option.key)}
-                className={`whitespace-nowrap px-4 md:px-5 py-2 rounded-full text-sm font-semibold transition-colors duration-200 border ${
-                  category === option.key
-                    ? "bg-blue-500 text-white border-blue-500 shadow-sm"
-                    : "bg-white text-blue-600 border-blue-300 hover:bg-blue-50"
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-            <label className="flex items-center gap-2 ml-auto text-sm font-semibold text-gray-700 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={isPrivate}
-                onChange={(e) => setIsPrivate(e.target.checked)}
-                className="w-4 h-4 accent-[#007AEB]"
-              />
-              비공개
-            </label>
+          {/* 부제목 */}
+          <div className="relative">
+            <input
+              type="text"
+              value={subtitle}
+              maxLength={SUBTITLE_MAX}
+              onChange={(e) => setSubtitle(e.target.value)}
+              placeholder="부제목을 입력하세요. (선택)"
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 pr-16 text-sm text-gray-800 placeholder-gray-400 focus:border-[#007AEB] focus:outline-none focus:ring-2 focus:ring-[#007AEB]/20"
+            />
+            <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs text-gray-400">
+              {subtitle.length}/{SUBTITLE_MAX}
+            </span>
           </div>
 
+          {/* 카테고리 선택 */}
+          <div className="flex flex-wrap gap-2.5">
+            {BLOG_CATEGORIES.map((c) => {
+              const active = category === c.key;
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={() => setCategory(c.key)}
+                  className={`inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-bold transition-colors ${
+                    active
+                      ? "border-[#007AEB] bg-[#007AEB] text-white"
+                      : "border-[#bcbcbc] bg-white text-[#4e4e4e] hover:border-[#007AEB] hover:text-[#007AEB]"
+                  }`}
+                >
+                  <c.Icon className="h-4 w-4" strokeWidth={2} />
+                  {c.label}
+                  <span className={`text-xs font-medium ${active ? "text-white/80" : "text-gray-400"}`}>
+                    ({c.hint})
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* 내용 */}
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            placeholder="내용을 입력하세요"
-            className="w-full h-64 p-4 text-sm leading-relaxed border border-gray-200 rounded-[15px] resize-vertical focus:outline-none focus:ring-2 focus:ring-[#007AEB] focus:border-transparent"
+            placeholder="내용을 입력하세요."
+            className="min-h-[20rem] w-full resize-y rounded-xl border border-gray-200 bg-white p-4 text-[15px] leading-8 text-gray-800 placeholder-gray-400 focus:border-[#007AEB] focus:outline-none focus:ring-2 focus:ring-[#007AEB]/20"
           />
 
-          {/* 썸네일 */}
-          <div className="border border-gray-200 rounded-[15px] p-4">
-            <label className="flex justify-between items-center cursor-pointer select-none">
-              <span className="text-sm font-semibold text-[#007AEB]">썸네일 이미지</span>
-              <span className="text-sm text-gray-500">
-                {thumbnail ? thumbnail.name : "선택 안 함"}
-              </span>
-              <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={(e) => setThumbnail(e.target.files?.[0] ?? null)}
-              />
-            </label>
-          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div className="space-y-6">
+              {/* 대표 이미지 */}
+              <section>
+                <h2 className="mb-2 text-sm font-bold text-gray-700">대표 이미지 (선택)</h2>
+                {thumbnailPreview ? (
+                  <div className="relative overflow-hidden rounded-xl border border-gray-200 bg-white">
+                    <div className="aspect-[16/9] w-full">
+                      <img
+                        src={thumbnailPreview}
+                        alt="대표 이미지 미리보기"
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                    <div className="flex items-center justify-between gap-2 px-3 py-2">
+                      <span className="truncate text-sm text-gray-600">{thumbnail?.name}</span>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <label className="cursor-pointer rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-semibold text-gray-600 hover:border-[#007AEB] hover:text-[#007AEB]">
+                          이미지 변경
+                          <input
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={(e) => setThumbnail(e.target.files?.[0] ?? null)}
+                          />
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => setThumbnail(null)}
+                          aria-label="대표 이미지 삭제"
+                          className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <label className="flex aspect-[16/9] cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-white text-gray-400 transition-colors hover:border-[#007AEB] hover:text-[#007AEB]">
+                    <ImagePlus className="h-8 w-8" strokeWidth={1.6} />
+                    <span className="text-sm font-medium">
+                      {isEdit ? "변경할 대표 이미지 선택" : "대표 이미지 선택"}
+                    </span>
+                    {isEdit && (
+                      <span className="text-xs text-gray-400">선택하지 않으면 기존 이미지가 유지됩니다</span>
+                    )}
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) => setThumbnail(e.target.files?.[0] ?? null)}
+                    />
+                  </label>
+                )}
+              </section>
 
-          {/* 본문 이미지 */}
-          <div className="border border-gray-200 rounded-[15px] p-4 space-y-2">
-            <label className="flex justify-between items-center cursor-pointer select-none">
-              <span className="text-sm font-semibold text-[#007AEB]">본문 이미지 추가</span>
-              <input
-                type="file"
-                accept="image/*"
-                multiple
-                className="hidden"
-                onChange={(e) => addPending(setImages, Array.from(e.target.files ?? []))}
-              />
-            </label>
-            {existingImageUrls.map((url, index) => (
-              <div key={url} className="flex items-center justify-between text-sm text-gray-600">
-                <span className="truncate">{blogFileName(url)}</span>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setExistingImageUrls((prev) => prev.filter((_, i) => i !== index))
-                  }
-                  className="ml-3 text-xs text-gray-400 hover:text-red-500"
-                >
-                  제거
-                </button>
-              </div>
-            ))}
-            {images.map((item) => (
-              <div key={item.id} className="flex items-center justify-between text-sm text-gray-600">
-                <span className="truncate">{item.file.name}</span>
-                <button
-                  type="button"
-                  onClick={() => setImages((prev) => prev.filter((f) => f.id !== item.id))}
-                  className="ml-3 text-xs text-gray-400 hover:text-red-500"
-                >
-                  제거
-                </button>
-              </div>
-            ))}
-          </div>
+              {/* 본문 이미지 */}
+              <section className="rounded-xl border border-gray-200 bg-white p-4">
+                <label className="flex cursor-pointer items-center justify-between">
+                  <span className="text-sm font-bold text-[#007AEB]">본문 이미지 추가</span>
+                  <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+                    <ImagePlus className="h-4 w-4" />
+                    {totalImages > 0 ? `${totalImages}개` : "선택"}
+                  </span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => addPending(setImages, Array.from(e.target.files ?? []))}
+                  />
+                </label>
+                {(existingImageUrls.length > 0 || images.length > 0) && (
+                  <ul className="mt-3 space-y-1.5">
+                    {existingImageUrls.map((url, index) => (
+                      <li key={url} className="flex items-center justify-between text-sm text-gray-600">
+                        <span className="truncate">{blogFileName(url)}</span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExistingImageUrls((prev) => prev.filter((_, i) => i !== index))
+                          }
+                          className="ml-3 shrink-0 text-xs text-gray-400 hover:text-red-500"
+                        >
+                          제거
+                        </button>
+                      </li>
+                    ))}
+                    {images.map((item) => (
+                      <li key={item.id} className="flex items-center justify-between text-sm text-gray-600">
+                        <span className="truncate">{item.file.name}</span>
+                        <button
+                          type="button"
+                          onClick={() => setImages((prev) => prev.filter((f) => f.id !== item.id))}
+                          className="ml-3 shrink-0 text-xs text-gray-400 hover:text-red-500"
+                        >
+                          제거
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
 
-          {/* 첨부파일 */}
-          <div className="border border-gray-200 rounded-[15px] p-4 space-y-2">
-            <label className="flex justify-between items-center cursor-pointer select-none">
-              <span className="text-sm font-semibold text-[#007AEB]">첨부파일 추가</span>
-              <input
-                type="file"
-                multiple
-                className="hidden"
-                onChange={(e) => addPending(setFiles, Array.from(e.target.files ?? []))}
-              />
-            </label>
-            {existingFileUrls.map((url, index) => (
-              <div key={url} className="flex items-center justify-between text-sm text-gray-600">
-                <span className="truncate">{blogFileName(url)}</span>
-                <button
-                  type="button"
-                  onClick={() => setExistingFileUrls((prev) => prev.filter((_, i) => i !== index))}
-                  className="ml-3 text-xs text-gray-400 hover:text-red-500"
-                >
-                  제거
-                </button>
-              </div>
-            ))}
-            {files.map((item) => (
-              <div key={item.id} className="flex items-center justify-between text-sm text-gray-600">
-                <span className="truncate">{item.file.name}</span>
-                <button
-                  type="button"
-                  onClick={() => setFiles((prev) => prev.filter((f) => f.id !== item.id))}
-                  className="ml-3 text-xs text-gray-400 hover:text-red-500"
-                >
-                  제거
-                </button>
-              </div>
-            ))}
-          </div>
+              {/* 파일 업로드 */}
+              <section className="rounded-xl border border-gray-200 bg-white p-4">
+                <label className="flex cursor-pointer items-center justify-between">
+                  <span className="text-sm font-bold text-[#007AEB]">파일 업로드</span>
+                  <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+                    <Paperclip className="h-4 w-4" />
+                    추가
+                  </span>
+                  <input
+                    type="file"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => addPending(setFiles, Array.from(e.target.files ?? []))}
+                  />
+                </label>
+                {(existingFileUrls.length > 0 || files.length > 0) && (
+                  <ul className="mt-3 space-y-1.5">
+                    {existingFileUrls.map((url, index) => (
+                      <li key={url} className="flex items-center justify-between text-sm text-gray-600">
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <Paperclip className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                          <span className="truncate">{blogFileName(url)}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExistingFileUrls((prev) => prev.filter((_, i) => i !== index))
+                          }
+                          className="ml-3 shrink-0 text-xs text-gray-400 hover:text-red-500"
+                        >
+                          삭제
+                        </button>
+                      </li>
+                    ))}
+                    {files.map((item) => (
+                      <li key={item.id} className="flex items-center justify-between text-sm text-gray-600">
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <Paperclip className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                          <span className="truncate">{item.file.name}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setFiles((prev) => prev.filter((f) => f.id !== item.id))}
+                          className="ml-3 shrink-0 text-xs text-gray-400 hover:text-red-500"
+                        >
+                          삭제
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </div>
 
-          <div className="flex justify-end gap-3">
-            <button
-              type="button"
-              onClick={() => navigate(isEdit ? `/blog/${id}` : "/blog")}
-              className="px-7 py-3 text-sm font-semibold text-gray-600 transition-colors rounded-full hover:text-gray-900"
-            >
-              취소
-            </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="px-7 py-3 text-sm font-semibold text-white bg-[#007AEB] rounded-full hover:bg-[#0066c7] transition-colors disabled:bg-gray-300"
-            >
-              {submitting ? "저장 중..." : isEdit ? "수정" : "등록"}
-            </button>
+            {/* 블로그 카드 미리보기 */}
+            <section>
+              <h2 className="mb-2 text-sm font-bold text-gray-700">블로그 카드 미리보기</h2>
+              <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                <div className="relative aspect-[16/9] w-full overflow-hidden bg-gray-100">
+                  {thumbnailPreview ? (
+                    <img
+                      src={thumbnailPreview}
+                      alt="카드 미리보기 썸네일"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-2xl font-black tracking-widest text-slate-300">
+                      CAPS
+                    </div>
+                  )}
+                  {previewCat && (
+                    <span className="absolute left-3 top-3 rounded-full bg-[#007AEB] px-3 py-1 text-xs font-bold text-white shadow-sm">
+                      {previewCat.label}
+                    </span>
+                  )}
+                  {isPrivate && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/45">
+                      <Lock className="h-8 w-8 text-white/90" strokeWidth={2} />
+                    </div>
+                  )}
+                </div>
+                <div className="p-5">
+                  <h3 className="truncate text-lg font-bold text-black">
+                    {title || "제목을 입력하세요."}
+                  </h3>
+                  {subtitle && <p className="mt-1.5 line-clamp-2 text-sm text-gray-500">{subtitle}</p>}
+                  <div className="mt-4 flex items-center justify-between text-xs text-[#9ca3af]">
+                    <span className="truncate">
+                      {user?.grade ? `${user.grade}기 ` : ""}
+                      {user?.name ?? ""}
+                    </span>
+                    <span className="shrink-0">
+                      {new Date().toLocaleDateString("ko-KR").replace(/\.$/, "")}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </section>
           </div>
         </form>
       </main>

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,9 +1,18 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { match } from "ts-pattern";
+import {
+  Pencil,
+  Lock,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
 import BlogImage from "../components/Blog/BlogImage";
+import { BLOG_CATEGORIES, blogCategoryLabel } from "../components/Blog/categories";
 import { useAuth } from "../hooks/useAuth";
 import { useGetBlogs, GetBlogsCategory, BlogListResponse } from "../api/generated/capsApi";
 
@@ -19,18 +28,14 @@ interface BlogListPage {
   totalElements?: number;
 }
 
-const CATEGORIES: { key: "ALL" | GetBlogsCategory; label: string }[] = [
+const FILTERS: { key: "ALL" | GetBlogsCategory; label: string; Icon?: React.ElementType }[] = [
   { key: "ALL", label: "전체" },
-  { key: GetBlogsCategory.EVENTS, label: "행사" },
-  { key: GetBlogsCategory.ACADEMIC, label: "학술" },
-  { key: GetBlogsCategory.TECH, label: "기술" },
+  ...BLOG_CATEGORIES.map((c) => ({
+    key: c.key as GetBlogsCategory,
+    label: c.label,
+    Icon: c.Icon,
+  })),
 ];
-
-const CATEGORY_LABEL: Record<string, string> = {
-  EVENTS: "행사",
-  ACADEMIC: "학술",
-  TECH: "기술",
-};
 
 function formatDate(iso?: string): string {
   if (!iso) return "";
@@ -39,7 +44,16 @@ function formatDate(iso?: string): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
-  return `${y}.${m}.${day}`;
+  return `${y}. ${m}. ${day}`;
+}
+
+/** 현재 페이지를 중심으로 최대 10개까지만 페이지 번호를 노출한다. */
+function pageWindow(current: number, total: number, size = 10): number[] {
+  if (total <= size) return Array.from({ length: total }, (_, i) => i + 1);
+  let start = Math.max(1, current - Math.floor(size / 2));
+  const end = Math.min(total, start + size - 1);
+  start = Math.max(1, end - size + 1);
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 }
 
 const BlogPage: React.FC = () => {
@@ -56,6 +70,10 @@ const BlogPage: React.FC = () => {
   const posts = pageData?.content ?? [];
   const totalPages = pageData?.totalPages && pageData.totalPages > 0 ? pageData.totalPages : 1;
 
+  const canWrite = match(user?.role)
+    .with("ADMIN", "COUNCIL", "PRESIDENT", () => true)
+    .otherwise(() => false);
+
   const handleCategory = (key: "ALL" | GetBlogsCategory) => {
     setCategory(key);
     setPage(1);
@@ -64,43 +82,43 @@ const BlogPage: React.FC = () => {
   return (
     <div className="bg-[#FAFAFA] min-h-screen">
       <Navbar />
-      <div className="pt-20 max-w-5xl mx-auto px-4 pb-20">
-        {/* 타이틀 */}
-        <div className="pt-8 pb-6 text-center">
-          <h1 className="text-3xl md:text-4xl font-bold text-black mb-3">블로그</h1>
-          <p className="text-gray-500">CAPS의 활동과 소식을 전합니다.</p>
+      <div className="pt-20 max-w-6xl mx-auto px-4 md:px-6 pb-24">
+        {/* 타이틀 + 작성하기 */}
+        <div className="flex flex-col gap-4 pt-10 pb-8 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight text-black">블로그</h1>
+            <p className="mt-3 text-base md:text-lg font-medium text-[#374151]">
+              CAPS의 활동과 기술적 인사이트를 텍스트로 기록하고 공유합니다
+            </p>
+          </div>
+          {canWrite && (
+            <button
+              type="button"
+              onClick={() => navigate("/blog/edit")}
+              className="inline-flex shrink-0 items-center gap-2 self-start rounded-full bg-[#007AEB] px-6 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#0069cc] sm:self-auto"
+            >
+              <Pencil className="h-4 w-4" strokeWidth={2.2} />
+              작성하기
+            </button>
+          )}
         </div>
 
-        {/* 작성하기 (집행부만) */}
-        {match(user?.role)
-          .with("ADMIN", "COUNCIL", "PRESIDENT", () => (
-            <div className="mb-6 flex justify-end">
-              <button
-                type="button"
-                onClick={() => navigate("/blog/edit")}
-                className="px-6 py-3 text-sm font-semibold text-white bg-[#007AEB] rounded-full hover:bg-[#0079ebcc] transition-colors"
-              >
-                작성하기
-              </button>
-            </div>
-          ))
-          .otherwise(() => null)}
-
         {/* 카테고리 필터 */}
-        <div className="flex flex-wrap justify-center gap-2 mb-10">
-          {CATEGORIES.map((c) => {
-            const active = category === c.key;
+        <div className="mb-10 flex flex-wrap gap-2.5">
+          {FILTERS.map((f) => {
+            const active = category === f.key;
             return (
               <button
-                key={c.key}
-                onClick={() => handleCategory(c.key)}
-                className={`whitespace-nowrap px-4 md:px-5 py-2 rounded-full text-sm md:text-base font-semibold transition-colors duration-200 border ${
+                key={f.key}
+                onClick={() => handleCategory(f.key)}
+                className={`inline-flex items-center gap-2 whitespace-nowrap rounded-xl border px-4 md:px-5 py-2.5 text-sm md:text-base font-bold transition-colors ${
                   active
-                    ? "bg-blue-500 text-white border-blue-500 shadow-sm"
-                    : "bg-white text-blue-600 border-blue-300 hover:bg-blue-50"
+                    ? "border-[#007AEB] bg-[#007AEB] text-white"
+                    : "border-[#bcbcbc] bg-white text-[#4e4e4e] hover:border-[#007AEB] hover:text-[#007AEB]"
                 }`}
               >
-                {c.label}
+                {f.Icon && <f.Icon className="h-4 w-4 md:h-5 md:w-5" strokeWidth={2} />}
+                {f.label}
               </button>
             );
           })}
@@ -114,41 +132,50 @@ const BlogPage: React.FC = () => {
             게시물을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
           </p>
         ) : posts.length === 0 ? (
-          <p className="text-center text-gray-400 py-20">아직 등록된 게시물이 없습니다.</p>
+          <p className="py-24 text-center text-lg font-bold tracking-wide text-[#374151]">
+            등록된 글이 없습니다.
+          </p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-8">
+          <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             {posts.map((post) => (
               <article
                 key={post.id}
                 onClick={() => navigate(`/blog/${post.id}`)}
-                className="group cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:shadow-md"
+                className="group cursor-pointer overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
               >
-                <div className="h-44 w-full overflow-hidden bg-gray-100">
+                <div className="relative aspect-[16/9] w-full overflow-hidden bg-gray-100">
                   <BlogImage
                     src={post.thumbnailUrl}
                     alt={post.title}
                     className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
                     fallback={
-                      <div className="flex h-full w-full items-center justify-center text-sm tracking-widest text-gray-300">
+                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-2xl font-black tracking-widest text-slate-300">
                         CAPS
                       </div>
                     }
                   />
-                </div>
-                <div className="p-4">
-                  <span className="mb-2 inline-block rounded-full bg-blue-500 px-3 py-0.5 text-xs font-semibold text-white">
-                    {CATEGORY_LABEL[post.category ?? ""] ?? post.category}
+                  {/* 카테고리 배지 */}
+                  <span className="absolute left-3 top-3 rounded-full bg-[#007AEB] px-3 py-1 text-xs font-bold text-white shadow-sm">
+                    {blogCategoryLabel(post.category)}
                   </span>
-                  <h3 className="truncate text-base font-semibold text-black">{post.title}</h3>
-                  {post.subtitle && (
-                    <p className="mt-1 line-clamp-2 text-sm text-gray-600">{post.subtitle}</p>
+                  {/* 비공개(관리자에게만 노출됨) */}
+                  {post.isPrivate && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/45">
+                      <Lock className="h-8 w-8 text-white/90" strokeWidth={2} />
+                    </div>
                   )}
-                  <div className="mt-3 flex items-center justify-between text-xs text-gray-400">
+                </div>
+                <div className="p-5">
+                  <h3 className="truncate text-lg font-bold text-black">{post.title}</h3>
+                  {post.subtitle && (
+                    <p className="mt-1.5 line-clamp-2 text-sm text-gray-500">{post.subtitle}</p>
+                  )}
+                  <div className="mt-4 flex items-center justify-between text-xs text-[#9ca3af]">
                     <span className="truncate">
+                      {post.writerGrade ? `${post.writerGrade}기 ` : ""}
                       {post.writerName}
-                      {post.writerGrade ? ` · ${post.writerGrade}기` : ""}
                     </span>
-                    <span>{formatDate(post.createdAt)}</span>
+                    <span className="shrink-0">{formatDate(post.createdAt)}</span>
                   </div>
                 </div>
               </article>
@@ -158,35 +185,54 @@ const BlogPage: React.FC = () => {
 
         {/* 페이지네이션 */}
         {!isLoading && !isError && totalPages > 1 && (
-          <div className="mt-12 flex items-center justify-center gap-4">
+          <nav className="mt-14 flex items-center justify-center gap-1.5 text-sm font-semibold text-gray-500">
+            <button
+              onClick={() => setPage(1)}
+              disabled={page <= 1}
+              aria-label="첫 페이지"
+              className="grid h-9 w-9 place-items-center rounded-full transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:text-gray-300"
+            >
+              <ChevronsLeft className="h-4 w-4" />
+            </button>
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page <= 1}
-              className="text-sm font-semibold text-gray-700 transition-colors hover:text-gray-900 disabled:text-gray-300"
+              aria-label="이전 페이지"
+              className="grid h-9 w-9 place-items-center rounded-full transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:text-gray-300"
             >
-              이전
+              <ChevronLeft className="h-4 w-4" />
             </button>
-            <div className="flex items-center gap-3">
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
-                <button
-                  key={p}
-                  onClick={() => setPage(p)}
-                  className={`text-sm font-semibold transition-colors ${
-                    p === page ? "text-blue-500" : "text-gray-500 hover:text-gray-800"
-                  }`}
-                >
-                  {p}
-                </button>
-              ))}
-            </div>
+            {pageWindow(page, totalPages).map((p) => (
+              <button
+                key={p}
+                onClick={() => setPage(p)}
+                aria-current={p === page ? "page" : undefined}
+                className={`grid h-9 w-9 place-items-center rounded-full transition-colors ${
+                  p === page
+                    ? "bg-[#007AEB] text-white"
+                    : "text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+                }`}
+              >
+                {p}
+              </button>
+            ))}
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page >= totalPages}
-              className="text-sm font-semibold text-gray-700 transition-colors hover:text-gray-900 disabled:text-gray-300"
+              aria-label="다음 페이지"
+              className="grid h-9 w-9 place-items-center rounded-full transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:text-gray-300"
             >
-              다음
+              <ChevronRight className="h-4 w-4" />
             </button>
-          </div>
+            <button
+              onClick={() => setPage(totalPages)}
+              disabled={page >= totalPages}
+              aria-label="마지막 페이지"
+              className="grid h-9 w-9 place-items-center rounded-full transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:text-gray-300"
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </button>
+          </nav>
         )}
       </div>
       <Footer />


### PR DESCRIPTION
## 배포 내용
`develop`을 `main`으로 릴리스합니다. 머지 시 `s3-deploy.yml`(S3 sync + CloudFront)로 **https://dgucaps.kr** 에 배포됩니다.

### 포함 커밋
- **#117 블로그 목록·상세·작성 피그마 디자인 반영** (이번 작업)
- `fix` LedgerBoard 소소한 변경 1건 (develop에 이미 올라와 있던 미배포분)

### 참고
- 헤더 `블로그` 메뉴는 여전히 **숨김** 상태라, 배포돼도 일반 방문자 메뉴에는 안 보이고 `/blog` 직접 접근으로만 열립니다. 메뉴 노출을 원하면 알려주세요(NavBar에 링크 복구).

🤖 Generated with [Claude Code](https://claude.com/claude-code)