### PR TITLE
feat: 위키 열람(조회)을 비회원까지 공개

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,12 +171,9 @@ const App: React.FC = () => {
       element: <MyPage />,
     },
     {
+      // 위키 열람(조회)은 비회원까지 공개. 편집/이력은 아래 라우트에서 계속 로그인 필요.
       path: "/wiki",
-      element: (
-        <ProtectedRoute>
-          <WikiPage />
-        </ProtectedRoute>
-      ),
+      element: <WikiPage />,
       children: [
         {
           path: ":wiki_title",


### PR DESCRIPTION
## 개요
#106에서 로그인 전용(`ProtectedRoute`)으로 전환했던 **위키 조회**를 되돌려 비회원도 문서를 읽을 수 있게 합니다.

## 변경
- `/wiki` (`WikiPage` + 자식 `:wiki_title` `WikiContent`) 라우트에서 `ProtectedRoute` 제거
- **편집 `/wiki/edit/:title`, 수정 이력 `/wiki/history/:title` 은 로그인 유지** (기존과 동일)

## 근거
- 위키 조회 데이터는 `axios.get(.../wikis/{title}, { withCredentials: true })` 쿠키 세션 기반 호출 → 백엔드가 이미 `permitAll`. #106은 프론트 게이팅만 추가한 것이라, 게이팅 제거만으로 공개 열람 복구.
- 조회 페이지 위젯(최근 변경/랜덤)도 쿠키 기반 plain 호출이라 비회원이 리다이렉트되지 않음. 검색 자동완성만 인증 필요 시 조용히 빈 결과.

## 확인
- `vite build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)