### PR TITLE
release: 위키 조회 공개 배포 (develop→main)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,12 +171,9 @@ const App: React.FC = () => {
       element: <MyPage />,
     },
     {
+      // 위키 열람(조회)은 비회원까지 공개. 편집/이력은 아래 라우트에서 계속 로그인 필요.
       path: "/wiki",
-      element: (
-        <ProtectedRoute>
-          <WikiPage />
-        </ProtectedRoute>
-      ),
+      element: <WikiPage />,
       children: [
         {
           path: ":wiki_title",


### PR DESCRIPTION
## 배포 내용
`develop`→`main` 릴리스. 머지 시 AWS Deploy(S3 + CloudFront)로 **https://dgucaps.kr** 배포.

### 포함
- **#119 위키 열람(조회) 비회원 공개** — `/wiki` 라우트 ProtectedRoute 제거 (편집/이력은 로그인 유지)

### 참고
- main에만 있던 LedgerBoard 오타 수정(9675705)은 develop이 해당 파일을 건드리지 않아 3-way 머지로 유지됩니다(되돌아가지 않음). 이번 릴리스로 main에 실제 반영되는 변경은 `src/App.tsx` 뿐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)