### PR TITLE
Chore/blog design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import KakaoLogin from "./pages/KakaoLogin";
 
 // Components
 import NavBar from "./components/NavBar.tsx";
+import ScrollToTop from "./components/common/ScrollToTop.tsx";
 
 // Wiki Components
 import { WikiContent } from "./components/WIKI/WikiContent";
@@ -207,6 +208,7 @@ const App: React.FC = () => {
     <QueryClientProvider client={queryClient}>
       <ConfigProvider locale={koKR}>
         <BrowserRouter>
+          <ScrollToTop />
           <UserProvider>
             <div className="min-h-screen bg-gray-50">
               {/* <NavBar /> */}

--- a/src/components/Blog/MarkdownEditor.tsx
+++ b/src/components/Blog/MarkdownEditor.tsx
@@ -9,6 +9,7 @@ import {
   Code,
   Link2,
   ImagePlus,
+  Table as TableIcon,
 } from "lucide-react";
 import MarkdownView from "./MarkdownView";
 
@@ -26,6 +27,8 @@ type Mode = "edit" | "preview";
 function escapeMarkdownLabel(text: string): string {
   return text.replace(/[\\[\]]/g, "\\$&");
 }
+
+const TABLE_TEMPLATE = "| 헤더1 | 헤더2 | 헤더3 |\n| --- | --- | --- |\n| 내용 | 내용 | 내용 |\n";
 
 const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   value,
@@ -95,6 +98,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     { key: "quote", Icon: Quote, label: "인용", run: () => wrap("> ", "", "인용", true) },
     { key: "code", Icon: Code, label: "코드", run: () => wrap("`", "`", "코드") },
     { key: "link", Icon: Link2, label: "링크", run: () => wrap("[", "](https://)", "링크 텍스트") },
+    { key: "table", Icon: TableIcon, label: "표", run: () => insertBlock(TABLE_TEMPLATE) },
   ];
 
   return (
@@ -164,10 +168,10 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="block min-h-[24rem] w-full resize-y bg-white p-4 font-mono text-[14px] leading-7 text-gray-800 placeholder-gray-400 focus:outline-none"
+          className="block min-h-[36rem] w-full resize-y bg-white p-4 font-mono text-[14px] leading-7 text-gray-800 placeholder-gray-400 focus:outline-none"
         />
       ) : (
-        <div className="min-h-[24rem] p-4">
+        <div className="min-h-[36rem] p-4">
           {value.trim() ? (
             <MarkdownView content={value} />
           ) : (

--- a/src/components/Ledger/LedgerComponents.tsx
+++ b/src/components/Ledger/LedgerComponents.tsx
@@ -12,21 +12,6 @@ export const attachFileIcon = new URL(
   import.meta.url
 ).href;
 
-export const attachFileUploadIcon = new URL(
-  "../../assets/attach_file_upload.svg",
-  import.meta.url
-).href;
-
-export const imageFileIcon = new URL(
-  "../../assets/image_file.svg",
-  import.meta.url
-).href;
-
-export const defaultFileIcon = new URL(
-  "../../assets/default_file.svg",
-  import.meta.url
-).href;
-
 /* =====================
  * 상세 페이지용 컴포넌트
  * ===================== */
@@ -322,82 +307,6 @@ export interface LedgerFileItem {
   id: number;
   file: File;
 }
-
-export interface FileSectionProps {
-  files: LedgerFileItem[];
-  onFilesChange: (files: File[]) => void;
-  onRemoveFile: (id: number) => void;
-}
-
-export const LedgerFileSection: React.FC<FileSectionProps> = ({
-  files,
-  onFilesChange,
-  onRemoveFile,
-}) => (
-  <section
-    className={`space-y-2 bg-white p-2 rounded-lg border border-gray-200 ${
-      files.length > 0 ? "w-[15rem]" : "w-[11rem]"
-    }`}
-  >
-    {/* 상단 파일 업로드 헤더 (아이콘 + 텍스트) */}
-    <label className="flex justify-between items-center px-2 py-1 cursor-pointer select-none">
-      <div className="flex items-center gap-2 text-sm font-semibold text-[#007AEB]">
-        <img src={attachFileUploadIcon} alt="파일 업로드" className="w-4 h-4" />
-        <span>파일 업로드</span>
-      </div>
-      <input
-        type="file"
-        multiple
-        className="hidden"
-        onChange={(e) => {
-          const fileList = e.target.files ? Array.from(e.target.files) : [];
-          onFilesChange(fileList);
-        }}
-      />
-    </label>
-
-    {/* 구분선 (파일이 있을 때만 표시) */}
-    {files.length > 0 && <div className="border-b border-gray-200" />}
-
-    {/* 첨부파일 목록 */}
-    {files.length > 0 && (
-      <ul className="space-y-1 text-sm text-gray-800">
-        {files.map(({ id, file }) => (
-          <li
-            key={id}
-            className="flex justify-between items-center px-2 py-1 h-8"
-          >
-            <div className="flex flex-1 gap-2 items-center min-w-0">
-              <img
-                src={
-                  file.type.startsWith("image/") ||
-                  /\.(png|jpe?g|gif|bmp|webp|svg)$/i.test(file.name)
-                    ? imageFileIcon
-                    : defaultFileIcon
-                }
-                alt="첨부"
-                className="flex-shrink-0 w-4 h-4"
-              />
-              <span
-                className="truncate max-w-[10rem] md:max-w-[14rem]"
-                title={file.name}
-              >
-                {file.name.replace(/^\d+_\d+_/, '')}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={() => onRemoveFile(id)}
-              className="ml-2 flex-shrink-0 w-12 md:w-16 text-xs font-semibold text-[#007AEB] text-right hover:underline"
-            >
-              삭제
-            </button>
-          </li>
-        ))}
-      </ul>
-    )}
-  </section>
-);
 
 export interface ContentSectionProps {
   content: string;

--- a/src/components/common/AttachmentList.tsx
+++ b/src/components/common/AttachmentList.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Paperclip, Image as ImageIcon } from "lucide-react";
+
+export interface AttachmentListItem {
+  id: string | number;
+  name: string;
+  loading?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+  onRemove?: () => void;
+}
+
+interface AttachmentListProps {
+  items: AttachmentListItem[];
+  className?: string;
+}
+
+const isImageName = (name: string) => /\.(png|jpe?g|gif|bmp|webp|svg)$/i.test(name);
+
+/** 블로그 상세/작성 및 장부게시판 작성 페이지가 공유하는 첨부파일 목록 UI. */
+const AttachmentList: React.FC<AttachmentListProps> = ({ items, className = "" }) => {
+  if (items.length === 0) return null;
+
+  return (
+    <ul
+      className={`divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 bg-white ${className}`}
+    >
+      {items.map((item) => {
+        const Icon = isImageName(item.name) ? ImageIcon : Paperclip;
+        const label = (
+          <span className="flex min-w-0 items-center gap-2">
+            <Icon className="h-4 w-4 shrink-0 text-[#007AEB]" strokeWidth={2} />
+            <span className="truncate">{item.loading ? "불러오는 중..." : item.name}</span>
+          </span>
+        );
+
+        return (
+          <li
+            key={item.id}
+            className="flex items-center justify-between gap-3 px-3.5 py-2.5 text-sm text-gray-700"
+          >
+            {item.onClick ? (
+              <button
+                type="button"
+                onClick={item.onClick}
+                className="flex min-w-0 flex-1 items-center gap-2 text-left transition-colors hover:text-[#007AEB]"
+              >
+                {label}
+              </button>
+            ) : (
+              label
+            )}
+            {item.onRemove && (
+              <button
+                type="button"
+                onClick={item.onRemove}
+                className="shrink-0 text-xs font-semibold text-[#007AEB] hover:underline"
+              >
+                삭제
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default AttachmentList;

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+
+const LIST_PATHS = ["/blog", "/ledger"] as const;
+
+function isListPath(path: string): path is (typeof LIST_PATHS)[number] {
+  return (LIST_PATHS as readonly string[]).includes(path);
+}
+
+/** 목록의 상세·작성·수정 등 하위 경로인지 (예: /blog/1, /ledger/edit) */
+function isListChild(listPath: string, path: string): boolean {
+  return path.startsWith(`${listPath}/`);
+}
+
+function readScrollY(): number {
+  return window.scrollY || document.documentElement.scrollTop || 0;
+}
+
+function writeScrollY(y: number) {
+  window.scrollTo(0, y);
+  document.documentElement.scrollTop = y;
+  document.body.scrollTop = y;
+}
+
+/**
+ * 기본: 경로가 바뀌면 스크롤을 최상단으로.
+ * 예외: 블로그/장부 상세·작성에서 해당 목록으로 돌아올 때는 이전 스크롤 위치를 복원한다.
+ *
+ * 목록 unmount 이후에는 scrollY 가 이미 0일 수 있어,
+ * 목록에 머무는 동안 scroll 이벤트로 위치를 계속 기록한다.
+ */
+const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+  const prevPathRef = useRef(pathname);
+  const listScrollRef = useRef<Partial<Record<(typeof LIST_PATHS)[number], number>>>({});
+  const pendingRestoreYRef = useRef<number | null>(null);
+
+  // 경로 변경 직후: 복원 목표를 먼저 확정 (다른 effect 가 메모리를 덮어쓰기 전에)
+  useLayoutEffect(() => {
+    const prev = prevPathRef.current;
+
+    const returningToList =
+      isListPath(pathname) && prev !== pathname && isListChild(pathname, prev);
+
+    if (returningToList) {
+      pendingRestoreYRef.current = listScrollRef.current[pathname] ?? 0;
+    } else {
+      pendingRestoreYRef.current = null;
+      writeScrollY(0);
+    }
+
+    prevPathRef.current = pathname;
+  }, [pathname]);
+
+  // 목록으로 복귀 시 컨텐츠 높이 확보될 때까지 스크롤 재적용
+  useEffect(() => {
+    const y = pendingRestoreYRef.current;
+    if (y == null || y <= 0) return;
+
+    let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = 40;
+
+    const tryRestore = () => {
+      if (cancelled) return;
+      writeScrollY(y);
+      attempts += 1;
+      const maxScroll = Math.max(
+        0,
+        document.documentElement.scrollHeight - window.innerHeight
+      );
+      if (maxScroll >= y - 8 || attempts >= maxAttempts) {
+        pendingRestoreYRef.current = null;
+        return;
+      }
+      window.setTimeout(tryRestore, 50);
+    };
+
+    const frame = window.requestAnimationFrame(tryRestore);
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+    };
+  }, [pathname]);
+
+  // 목록에 있는 동안 스크롤만 기록 (마운트 직후 save 금지 — 복원 값을 0으로 덮어씀)
+  useEffect(() => {
+    if (!isListPath(pathname)) return;
+
+    const save = () => {
+      // 복원 재시도 중에는 덮어쓰지 않음
+      if (pendingRestoreYRef.current != null) return;
+      listScrollRef.current[pathname] = readScrollY();
+    };
+
+    window.addEventListener("scroll", save, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", save);
+    };
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/components/common/ScrollToTopButton.tsx
+++ b/src/components/common/ScrollToTopButton.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+/** 스크롤을 일정 이상 내렸을 때만 나타나는, 최상단으로 이동하는 우측 하단 버튼. */
+const ScrollToTopButton: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      aria-label="맨 위로 이동"
+      className="fixed bottom-6 right-6 z-40 grid h-11 w-11 place-items-center rounded-full bg-[#007AEB]/10 text-[#007AEB] shadow-lg transition-colors hover:bg-[#007AEB]/20"
+    >
+      <ArrowUp className="h-5 w-5" strokeWidth={2.4} />
+    </button>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/hooks/useConfirmLeaveOnUnload.ts
+++ b/src/hooks/useConfirmLeaveOnUnload.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+/** 새로고침/탭 닫기 등 브라우저 레벨 이탈 시 저장되지 않은 내용에 대한 경고를 띄운다. */
+export function useConfirmLeaveOnUnload(enabled = true) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [enabled]);
+}

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -3,11 +3,13 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { match } from "ts-pattern";
 import axios from "axios";
-import { ChevronLeft, Paperclip, Lock } from "lucide-react";
+import { ChevronLeft, Lock } from "lucide-react";
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
 import BlogImage from "../components/Blog/BlogImage";
 import MarkdownView from "../components/Blog/MarkdownView";
+import AttachmentList from "../components/common/AttachmentList";
+import ScrollToTopButton from "../components/common/ScrollToTopButton";
 import { BLOG_CATEGORY_MAP, blogCategoryLabel } from "../components/Blog/categories";
 import { useAuth } from "../hooks/useAuth";
 import { resolveBlogFileUrl, blogFileName } from "../utils/blogFiles";
@@ -123,12 +125,12 @@ const BlogDetailPage: React.FC = () => {
             {/* 카테고리 + 수정/삭제 */}
             <div className="mb-5 flex items-center justify-between gap-4">
               {cat ? (
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-[#007AEB] px-3.5 py-1 text-sm font-bold text-white">
+                <span className="inline-flex items-center gap-1.5 rounded-lg bg-[#007AEB]/10 px-3.5 py-1.5 text-sm font-bold text-[#007AEB]">
                   <cat.Icon className="h-4 w-4" strokeWidth={2} />
                   {cat.label}
                 </span>
               ) : (
-                <span className="inline-block rounded-full bg-[#007AEB] px-3.5 py-1 text-sm font-bold text-white">
+                <span className="inline-block rounded-lg bg-[#007AEB]/10 px-3.5 py-1.5 text-sm font-bold text-[#007AEB]">
                   {blogCategoryLabel(post.category)}
                 </span>
               )}
@@ -194,40 +196,25 @@ const BlogDetailPage: React.FC = () => {
 
             {post.fileUrls && post.fileUrls.length > 0 && (
               <div className="mt-10 border-t border-gray-200 pt-6">
-                <p className="mb-3 text-sm font-bold text-gray-700">첨부파일</p>
-                <ul className="flex flex-col gap-2">
-                  {post.fileUrls.map((url, i) => (
-                    <li key={i}>
-                      <a
-                        href="#"
-                        onClick={(e) => handleFileClick(url, e)}
-                        className="inline-flex max-w-full items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 transition-colors hover:border-[#007AEB] hover:text-[#007AEB]"
-                      >
-                        <Paperclip className="h-4 w-4 shrink-0" strokeWidth={2} />
-                        <span className="truncate">
-                          {loadingFile === url
-                            ? "불러오는 중..."
-                            : blogFileName(url) || `첨부파일 ${i + 1}`}
-                        </span>
-                      </a>
-                    </li>
-                  ))}
-                </ul>
+                <section className="w-full rounded-xl border border-gray-200 bg-white p-4 lg:max-w-[348px]">
+                  <p className="text-sm font-bold text-gray-700">첨부파일</p>
+                  <AttachmentList
+                    className="mt-3"
+                    items={post.fileUrls.map((url, i) => ({
+                      id: `${url}-${i}`,
+                      name: blogFileName(url) || `첨부파일 ${i + 1}`,
+                      loading: loadingFile === url,
+                      onClick: (e) => handleFileClick(url, e),
+                    }))}
+                  />
+                </section>
               </div>
             )}
-
-            <div className="mt-12 flex justify-center">
-              <button
-                onClick={() => navigate("/blog")}
-                className="rounded-full bg-[#007AEB] px-8 py-3 text-sm font-bold text-white transition-colors hover:bg-[#0069cc]"
-              >
-                목록
-              </button>
-            </div>
           </article>
         ) : null}
       </div>
       <Footer />
+      <ScrollToTopButton />
     </div>
   );
 };

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -194,8 +194,8 @@ const BlogDetailPage: React.FC = () => {
               </div>
             )}
 
-            {post.fileUrls && post.fileUrls.length > 0 && (
-              <div className="mt-10 border-t border-gray-200 pt-6">
+            <div className="mt-10 border-t border-gray-200 pt-6">
+              {post.fileUrls && post.fileUrls.length > 0 && (
                 <section className="w-full rounded-xl border border-gray-200 bg-white p-4 lg:max-w-[348px]">
                   <p className="text-sm font-bold text-gray-700">첨부파일</p>
                   <AttachmentList
@@ -208,8 +208,8 @@ const BlogDetailPage: React.FC = () => {
                     }))}
                   />
                 </section>
-              </div>
-            )}
+              )}
+            </div>
           </article>
         ) : null}
       </div>

--- a/src/pages/BlogEditPage.tsx
+++ b/src/pages/BlogEditPage.tsx
@@ -8,6 +8,7 @@ import Footer from "../components/MainPage/Footer";
 import { BLOG_CATEGORIES, BLOG_CATEGORY_MAP } from "../components/Blog/categories";
 import MarkdownEditor from "../components/Blog/MarkdownEditor";
 import BlogImage from "../components/Blog/BlogImage";
+import AttachmentList from "../components/common/AttachmentList";
 import { useAuth } from "../hooks/useAuth";
 import { uploadFileToS3, uploadMultipleFilesToS3, sanitizeFileName } from "../utils/s3Upload";
 import { blogFileName } from "../utils/blogFiles";
@@ -358,137 +359,115 @@ const BlogEditPage: React.FC = () => {
             />
           </div>
 
-          <div className="grid gap-6 lg:grid-cols-2">
-            <div className="space-y-6">
-              {/* 대표 이미지 */}
-              <section>
-                <h2 className="mb-2 text-sm font-bold text-gray-700">대표 이미지 (선택)</h2>
-                {showThumbnailPreview ? (
-                  <div className="relative overflow-hidden rounded-xl border border-gray-200 bg-white">
-                    <div className="aspect-[16/9] w-full">
-                      {thumbnailPreview ? (
-                        <img
-                          src={thumbnailPreview}
-                          alt="대표 이미지 미리보기"
-                          className="h-full w-full object-cover"
-                        />
-                      ) : (
-                        <BlogImage
-                          src={showThumbnailPreview}
-                          alt="현재 대표 이미지"
-                          className="h-full w-full object-cover"
-                          fallback={
-                            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-2xl font-black tracking-widest text-slate-300">
-                              CAPS
-                            </div>
-                          }
-                        />
-                      )}
-                    </div>
-                    <div className="flex items-center justify-between gap-2 px-3 py-2">
-                      <span className="truncate text-sm text-gray-600">
-                        {thumbnail ? thumbnail.name : "현재 대표 이미지"}
-                      </span>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <label className="cursor-pointer rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-semibold text-gray-600 hover:border-[#007AEB] hover:text-[#007AEB]">
-                          이미지 변경
-                          <input
-                            type="file"
-                            accept="image/*"
-                            className="hidden"
-                            onChange={(e) => {
-                              setThumbnail(e.target.files?.[0] ?? null);
-                              setRemovedThumbnail(false);
-                            }}
-                          />
-                        </label>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (thumbnail) setThumbnail(null);
-                            else setRemovedThumbnail(true);
+          <div className="grid grid-cols-1 gap-6 [grid-template-areas:'thumb'_'preview'_'files'] lg:grid-cols-2 lg:[grid-template-areas:'thumb_preview'_'files_preview']">
+            {/* 대표 이미지 */}
+            <section className="[grid-area:thumb]">
+              <h2 className="mb-2 text-sm font-bold text-gray-700">대표 이미지 (선택)</h2>
+              {showThumbnailPreview ? (
+                <div className="relative overflow-hidden rounded-xl border border-gray-200 bg-white">
+                  <div className="aspect-[16/9] w-full">
+                    {thumbnailPreview ? (
+                      <img
+                        src={thumbnailPreview}
+                        alt="대표 이미지 미리보기"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <BlogImage
+                        src={showThumbnailPreview}
+                        alt="현재 대표 이미지"
+                        className="h-full w-full object-cover"
+                        fallback={
+                          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-2xl font-black tracking-widest text-slate-300">
+                            CAPS
+                          </div>
+                        }
+                      />
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between gap-2 px-3 py-2">
+                    <span className="truncate text-sm text-gray-600">
+                      {thumbnail ? thumbnail.name : "현재 대표 이미지"}
+                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <label className="cursor-pointer rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-semibold text-gray-600 hover:border-[#007AEB] hover:text-[#007AEB]">
+                        이미지 변경
+                        <input
+                          type="file"
+                          accept="image/*"
+                          className="hidden"
+                          onChange={(e) => {
+                            setThumbnail(e.target.files?.[0] ?? null);
+                            setRemovedThumbnail(false);
                           }}
-                          aria-label="대표 이미지 삭제"
-                          className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (thumbnail) setThumbnail(null);
+                          else setRemovedThumbnail(true);
+                        }}
+                        aria-label="대표 이미지 삭제"
+                        className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
                     </div>
                   </div>
-                ) : (
-                  <label className="flex aspect-[16/9] cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-white text-gray-400 transition-colors hover:border-[#007AEB] hover:text-[#007AEB]">
-                    <ImagePlus className="h-8 w-8" strokeWidth={1.6} />
-                    <span className="text-sm font-medium">대표 이미지 선택</span>
-                    <input
-                      type="file"
-                      accept="image/*"
-                      className="hidden"
-                      onChange={(e) => {
-                        setThumbnail(e.target.files?.[0] ?? null);
-                        setRemovedThumbnail(false);
-                      }}
-                    />
-                  </label>
-                )}
-              </section>
-
-              {/* 파일 업로드 */}
-              <section className="rounded-xl border border-gray-200 bg-white p-4">
-                <label className="flex cursor-pointer items-center justify-between">
-                  <span className="text-sm font-bold text-[#007AEB]">파일 업로드</span>
-                  <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
-                    <Paperclip className="h-4 w-4" />
-                    추가
-                  </span>
+                </div>
+              ) : (
+                <label className="flex aspect-[16/9] cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-white text-gray-400 transition-colors hover:border-[#007AEB] hover:text-[#007AEB]">
+                  <ImagePlus className="h-8 w-8" strokeWidth={1.6} />
+                  <span className="text-sm font-medium">대표 이미지 선택</span>
                   <input
                     type="file"
-                    multiple
+                    accept="image/*"
                     className="hidden"
-                    onChange={(e) => addFiles(Array.from(e.target.files ?? []))}
+                    onChange={(e) => {
+                      setThumbnail(e.target.files?.[0] ?? null);
+                      setRemovedThumbnail(false);
+                    }}
                   />
                 </label>
-                {(existingFileUrls.length > 0 || files.length > 0) && (
-                  <ul className="mt-3 space-y-1.5">
-                    {existingFileUrls.map((url, index) => (
-                      <li key={url} className="flex items-center justify-between text-sm text-gray-600">
-                        <span className="flex min-w-0 items-center gap-1.5">
-                          <Paperclip className="h-3.5 w-3.5 shrink-0 text-gray-400" />
-                          <span className="truncate">{blogFileName(url)}</span>
-                        </span>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setExistingFileUrls((prev) => prev.filter((_, i) => i !== index))
-                          }
-                          className="ml-3 shrink-0 text-xs text-gray-400 hover:text-red-500"
-                        >
-                          삭제
-                        </button>
-                      </li>
-                    ))}
-                    {files.map((item) => (
-                      <li key={item.id} className="flex items-center justify-between text-sm text-gray-600">
-                        <span className="flex min-w-0 items-center gap-1.5">
-                          <Paperclip className="h-3.5 w-3.5 shrink-0 text-gray-400" />
-                          <span className="truncate">{item.file.name}</span>
-                        </span>
-                        <button
-                          type="button"
-                          onClick={() => setFiles((prev) => prev.filter((f) => f.id !== item.id))}
-                          className="ml-3 shrink-0 text-xs text-gray-400 hover:text-red-500"
-                        >
-                          삭제
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </section>
-            </div>
+              )}
+            </section>
+
+            {/* 파일 업로드 */}
+            <section className="[grid-area:files] rounded-xl border border-gray-200 bg-white p-4">
+              <label className="flex cursor-pointer items-center justify-between">
+                <span className="text-sm font-bold text-[#007AEB]">파일 업로드</span>
+                <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+                  <Paperclip className="h-4 w-4" />
+                  추가
+                </span>
+                <input
+                  type="file"
+                  multiple
+                  className="hidden"
+                  onChange={(e) => addFiles(Array.from(e.target.files ?? []))}
+                />
+              </label>
+              <AttachmentList
+                className="mt-3"
+                items={[
+                  ...existingFileUrls.map((url, index) => ({
+                    id: `existing-${url}`,
+                    name: blogFileName(url),
+                    onRemove: () =>
+                      setExistingFileUrls((prev) => prev.filter((_, i) => i !== index)),
+                  })),
+                  ...files.map((item) => ({
+                    id: item.id,
+                    name: item.file.name,
+                    onRemove: () => setFiles((prev) => prev.filter((f) => f.id !== item.id)),
+                  })),
+                ]}
+              />
+            </section>
 
             {/* 블로그 카드 미리보기 */}
-            <section>
+            <section className="[grid-area:preview]">
               <h2 className="mb-2 text-sm font-bold text-gray-700">블로그 카드 미리보기</h2>
               <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
                 <div className="relative aspect-[16/9] w-full overflow-hidden bg-gray-100">

--- a/src/pages/BlogEditPage.tsx
+++ b/src/pages/BlogEditPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { message } from "antd";
 import { Lock, Trash2, Paperclip, ImagePlus } from "lucide-react";
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
@@ -10,8 +11,10 @@ import MarkdownEditor from "../components/Blog/MarkdownEditor";
 import BlogImage from "../components/Blog/BlogImage";
 import AttachmentList from "../components/common/AttachmentList";
 import { useAuth } from "../hooks/useAuth";
+import { useConfirmLeaveOnUnload } from "../hooks/useConfirmLeaveOnUnload";
 import { uploadFileToS3, uploadMultipleFilesToS3, sanitizeFileName } from "../utils/s3Upload";
 import { blogFileName } from "../utils/blogFiles";
+import { confirmLeave } from "../utils/confirmLeave";
 import {
   useGetBlog,
   useCreateBlog,
@@ -25,7 +28,7 @@ import {
 const WRITE_ROLES = ["ADMIN", "COUNCIL", "PRESIDENT"];
 
 const TITLE_MAX = 50;
-const SUBTITLE_MAX = 50;
+const SUBTITLE_MAX = 100;
 
 /** 백엔드는 상세 응답에 thumbnailUrl 을 추가했지만 생성된 타입엔 아직 없어 확장해서 읽는다. */
 type BlogDetail = BlogDetailResponse & { thumbnailUrl?: string };
@@ -85,6 +88,8 @@ const BlogEditPage: React.FC = () => {
   const { mutateAsync: modifyBlog } = useModifyBlog();
 
   const canWrite = WRITE_ROLES.includes(user?.role ?? "");
+
+  useConfirmLeaveOnUnload();
 
   // 새로 고른 썸네일 미리보기 (URL 은 언마운트/교체 시 해제한다)
   const thumbnailPreview = useMemo(
@@ -214,12 +219,12 @@ const BlogEditPage: React.FC = () => {
         await modifyBlog({ blogId: id, data: payload as any });
         await queryClient.invalidateQueries({ queryKey: getGetBlogQueryKey(id) });
         await queryClient.invalidateQueries({ queryKey: getGetBlogsQueryKey() });
-        alert("게시물이 수정되었습니다.");
+        message.success("게시물이 수정되었습니다.");
         navigate(`/blog/${id}`);
       } else {
         const created = (await createBlog({ data: payload as any })) as any;
         await queryClient.invalidateQueries({ queryKey: getGetBlogsQueryKey() });
-        alert("게시물이 등록되었습니다.");
+        message.success("게시물이 등록되었습니다.");
         const newId = created?.data?.id;
         navigate(newId ? `/blog/${newId}` : "/blog");
       }
@@ -248,7 +253,7 @@ const BlogEditPage: React.FC = () => {
           {/* 헤더: 제목 + 비공개 토글 + 취소/발행 */}
           <div className="flex flex-col gap-4 border-b border-gray-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
             <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight text-black">블로그</h1>
-            <div className="flex flex-wrap items-center gap-2.5">
+            <div className="flex flex-wrap items-center justify-end gap-2.5">
               <button
                 type="button"
                 onClick={() => setIsPrivate((v) => !v)}
@@ -275,7 +280,9 @@ const BlogEditPage: React.FC = () => {
               </button>
               <button
                 type="button"
-                onClick={() => navigate(isEdit ? `/blog/${id}` : "/blog")}
+                onClick={() => {
+                  if (confirmLeave()) navigate(isEdit ? `/blog/${id}` : "/blog");
+                }}
                 className="rounded-full border border-gray-300 px-6 py-2.5 text-sm font-bold text-gray-600 transition-colors hover:text-gray-900"
               >
                 취소
@@ -285,7 +292,7 @@ const BlogEditPage: React.FC = () => {
                 disabled={submitting}
                 className="rounded-full bg-[#007AEB] px-7 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#0069cc] disabled:bg-gray-300"
               >
-                {submitting ? "저장 중..." : isEdit ? "수정" : "발행"}
+                {submitting ? "저장 중..." : isEdit ? "수정" : "작성"}
               </button>
             </div>
           </div>
@@ -321,7 +328,7 @@ const BlogEditPage: React.FC = () => {
           </div>
 
           {/* 카테고리 선택 */}
-          <div className="flex flex-wrap gap-2.5">
+          <div className="flex flex-wrap gap-1.5">
             {BLOG_CATEGORIES.map((c) => {
               const active = category === c.key;
               return (
@@ -329,7 +336,7 @@ const BlogEditPage: React.FC = () => {
                   key={c.key}
                   type="button"
                   onClick={() => setCategory(c.key)}
-                  className={`inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-bold transition-colors ${
+                  className={`inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg border px-3 py-1.5 text-sm font-bold transition-colors ${
                     active
                       ? "border-[#007AEB] bg-[#007AEB] text-white"
                       : "border-[#bcbcbc] bg-white text-[#4e4e4e] hover:border-[#007AEB] hover:text-[#007AEB]"
@@ -337,9 +344,6 @@ const BlogEditPage: React.FC = () => {
                 >
                   <c.Icon className="h-4 w-4" strokeWidth={2} />
                   {c.label}
-                  <span className={`text-xs font-medium ${active ? "text-white/80" : "text-gray-400"}`}>
-                    ({c.hint})
-                  </span>
                 </button>
               );
             })}

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -105,20 +105,20 @@ const BlogPage: React.FC = () => {
         </div>
 
         {/* 카테고리 필터 */}
-        <div className="mb-10 flex flex-nowrap gap-1.5 md:flex-wrap md:gap-2">
+        <div className="mb-10 flex flex-wrap gap-1.5">
           {FILTERS.map((f) => {
             const active = category === f.key;
             return (
               <button
                 key={f.key}
                 onClick={() => handleCategory(f.key)}
-                className={`inline-flex items-center gap-1 whitespace-nowrap rounded-lg border px-2.5 py-1 text-xs font-bold transition-colors md:gap-1.5 md:px-3.5 md:py-1.5 md:text-sm ${
+                className={`inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg border px-4 py-[7px] text-sm font-bold transition-colors ${
                   active
                     ? "border-[#007AEB] bg-[#007AEB] text-white"
                     : "border-[#bcbcbc] bg-white text-[#4e4e4e] hover:border-[#007AEB] hover:text-[#007AEB]"
                 }`}
               >
-                {f.Icon && <f.Icon className="h-3 w-3 md:h-3.5 md:w-3.5" strokeWidth={2} />}
+                {f.Icon && <f.Icon className="h-[15px] w-[15px]" strokeWidth={2} />}
                 {f.label}
               </button>
             );

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -12,6 +12,7 @@ import {
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
 import BlogImage from "../components/Blog/BlogImage";
+import logoGradient from "../assets/logo-gradient.png";
 import { BLOG_CATEGORIES, blogCategoryLabel } from "../components/Blog/categories";
 import { useAuth } from "../hooks/useAuth";
 import { useGetBlogs, GetBlogsCategory, BlogListResponse } from "../api/generated/capsApi";
@@ -86,8 +87,8 @@ const BlogPage: React.FC = () => {
         {/* 타이틀 + 작성하기 */}
         <div className="flex flex-col gap-4 pt-10 pb-8 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight text-black">블로그</h1>
-            <p className="mt-3 text-base md:text-lg font-medium text-[#374151]">
+            <h1 className="text-2xl font-extrabold tracking-tight text-black">블로그</h1>
+            <p className="mt-3 text-sm md:text-base font-medium text-[#374151]">
               CAPS의 활동과 기술적 인사이트를 텍스트로 기록하고 공유합니다
             </p>
           </div>
@@ -104,20 +105,20 @@ const BlogPage: React.FC = () => {
         </div>
 
         {/* 카테고리 필터 */}
-        <div className="mb-10 flex flex-wrap gap-2.5">
+        <div className="mb-10 flex flex-nowrap gap-1.5 md:flex-wrap md:gap-2">
           {FILTERS.map((f) => {
             const active = category === f.key;
             return (
               <button
                 key={f.key}
                 onClick={() => handleCategory(f.key)}
-                className={`inline-flex items-center gap-2 whitespace-nowrap rounded-xl border px-4 md:px-5 py-2.5 text-sm md:text-base font-bold transition-colors ${
+                className={`inline-flex items-center gap-1 whitespace-nowrap rounded-lg border px-2.5 py-1 text-xs font-bold transition-colors md:gap-1.5 md:px-3.5 md:py-1.5 md:text-sm ${
                   active
                     ? "border-[#007AEB] bg-[#007AEB] text-white"
                     : "border-[#bcbcbc] bg-white text-[#4e4e4e] hover:border-[#007AEB] hover:text-[#007AEB]"
                 }`}
               >
-                {f.Icon && <f.Icon className="h-4 w-4 md:h-5 md:w-5" strokeWidth={2} />}
+                {f.Icon && <f.Icon className="h-3 w-3 md:h-3.5 md:w-3.5" strokeWidth={2} />}
                 {f.label}
               </button>
             );
@@ -141,16 +142,18 @@ const BlogPage: React.FC = () => {
               <article
                 key={post.id}
                 onClick={() => navigate(`/blog/${post.id}`)}
-                className="group cursor-pointer overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                className={`group flex h-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-gray-200 p-2 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${
+                  post.isPrivate ? "bg-gray-100" : "bg-white"
+                }`}
               >
-                <div className="relative aspect-[16/9] w-full overflow-hidden bg-gray-100">
+                <div className="relative aspect-[16/9] w-full overflow-hidden rounded-xl bg-gray-100">
                   <BlogImage
                     src={post.thumbnailUrl}
                     alt={post.title}
                     className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
                     fallback={
-                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-2xl font-black tracking-widest text-slate-300">
-                        CAPS
+                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200">
+                        <img src={logoGradient} alt="CAPS" className="h-10 w-auto opacity-70" />
                       </div>
                     }
                   />
@@ -165,12 +168,24 @@ const BlogPage: React.FC = () => {
                     </div>
                   )}
                 </div>
-                <div className="p-5">
-                  <h3 className="truncate text-lg font-bold text-black">{post.title}</h3>
-                  {post.subtitle && (
-                    <p className="mt-1.5 line-clamp-2 text-sm text-gray-500">{post.subtitle}</p>
-                  )}
-                  <div className="mt-4 flex items-center justify-between text-xs text-[#9ca3af]">
+                <div className="flex flex-1 flex-col px-2 pb-1 pt-4">
+                  <div>
+                    <h3
+                      className={`truncate text-lg font-bold ${
+                        post.isPrivate ? "text-gray-600" : "text-black"
+                      }`}
+                    >
+                      {post.title}
+                    </h3>
+                    <p className="mt-1.5 line-clamp-2 min-h-[2.5rem] text-sm text-gray-500">
+                      {post.subtitle || "\u00A0"}
+                    </p>
+                  </div>
+                  <div
+                    className={`mt-auto flex items-center justify-between pt-4 text-xs ${
+                      post.isPrivate ? "text-gray-500" : "text-[#9ca3af]"
+                    }`}
+                  >
                     <span className="truncate">
                       {post.writerGrade ? `${post.writerGrade}기 ` : ""}
                       {post.writerName}

--- a/src/pages/LedgerEditPage.tsx
+++ b/src/pages/LedgerEditPage.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { Paperclip } from "lucide-react";
 import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
+import AttachmentList from "../components/common/AttachmentList";
 import {
   LedgerTitleInput,
   LedgerTopActions,
   LedgerBottomActions,
-  LedgerFileSection,
   LedgerContentSection,
   LedgerFileItem,
 } from "../components/Ledger/LedgerComponents";
@@ -219,41 +220,38 @@ const LedgerEditPage: React.FC = () => {
 
           {/* 내용 입력 */}
           <LedgerContentSection content={content} onChange={setContent} />
-          {/* 파일 업로드 */}
-          <div className="space-y-2">
-            <LedgerFileSection
-              files={files}
-              onFilesChange={handleFilesChange}
-              onRemoveFile={handleRemoveFile}
+          {/* 파일 업로드 (블로그 작성/수정 페이지의 파일 업로드 리스트와 가로 길이를 맞춘다) */}
+          <section className="w-full rounded-xl border border-gray-200 bg-white p-4 lg:max-w-[348px]">
+            <label className="flex cursor-pointer items-center justify-between">
+              <span className="text-sm font-bold text-[#007AEB]">파일 업로드</span>
+              <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+                <Paperclip className="h-4 w-4" />
+                추가
+              </span>
+              <input
+                type="file"
+                multiple
+                className="hidden"
+                onChange={(e) => handleFilesChange(Array.from(e.target.files ?? []))}
+              />
+            </label>
+            <AttachmentList
+              className="mt-3"
+              items={[
+                ...existingFileUrls.map((url) => ({
+                  id: `existing-${url}`,
+                  name: url.split("/").pop()?.replace(/^\d+_\d+_/, "") || "첨부파일",
+                  onRemove: () => handleRemoveExistingFile(url),
+                })),
+                ...files.map((item) => ({
+                  id: item.id,
+                  name: item.file.name,
+                  onRemove: () => handleRemoveFile(item.id),
+                })),
+              ]}
             />
-            {/* 기존 파일 표시 및 삭제 */}
-            {existingFileUrls.length > 0 && (
-              <div className="space-y-2">
-                {existingFileUrls.map((fileUrl, index) => (
-                  <div
-                    key={index}
-                    className="flex gap-2 items-center px-4 py-2 bg-gray-50 rounded-lg border border-gray-200"
-                  >
-                    <span className="text-sm text-gray-700">
-                      기존 파일: {fileUrl.split("/").pop()?.replace(/^\d+_\d+_/, '') || "첨부파일"}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveExistingFile(fileUrl)}
-                      className="px-3 py-1 text-xs font-semibold text-red-600 bg-red-50 rounded transition-colors hover:bg-red-100"
-                    >
-                      삭제
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-            {uploading && (
-              <div className="px-4 py-2 text-sm text-blue-600 bg-blue-50 rounded-lg">
-                업로드 중...
-              </div>
-            )}
-          </div>
+            {uploading && <p className="mt-3 text-sm font-medium text-[#007AEB]">업로드 중...</p>}
+          </section>
           {/* 하단 목록 버튼 */}
           <LedgerBottomActions onCancel={handleListClick} />
         </form>

--- a/src/pages/LedgerEditPage.tsx
+++ b/src/pages/LedgerEditPage.tsx
@@ -17,11 +17,13 @@ import {
   apiPostWithToken,
 } from "../utils/Api";
 import { useAuth } from "../hooks/useAuth";
+import { useConfirmLeaveOnUnload } from "../hooks/useConfirmLeaveOnUnload";
 import {
   uploadFileToS3,
   uploadMultipleFilesToS3,
   deleteFileFromS3,
 } from "../utils/s3Upload";
+import { confirmLeave } from "../utils/confirmLeave";
 
 interface LedgerEditResponse {
   status: number;
@@ -39,6 +41,8 @@ const LedgerEditPage: React.FC = () => {
   const { ledgerId } = useParams<{ ledgerId?: string }>();
   const navigate = useNavigate();
   const { isLoggedIn, isLoading } = useAuth();
+
+  useConfirmLeaveOnUnload();
 
   const [title, setTitle] = useState<string>("");
   const [content, setContent] = useState<string>("");
@@ -105,8 +109,14 @@ const LedgerEditPage: React.FC = () => {
   };
 
   const handleListClick = () => {
-    if (window.confirm("이 페이지를 떠나겠습니까?")) {
+    if (confirmLeave()) {
       navigate("/ledger");
+    }
+  };
+
+  const handleCancelClick = () => {
+    if (confirmLeave()) {
+      navigate(-1);
     }
   };
 
@@ -210,7 +220,7 @@ const LedgerEditPage: React.FC = () => {
             <LedgerTopActions
               isPinned={isPinned}
               onTogglePin={() => setIsPinned((prev) => !prev)}
-              onCancel={() => navigate(-1)}
+              onCancel={handleCancelClick}
               submitLabel={ledgerId ? "수정" : "등록"}
             />
           </div>

--- a/src/utils/confirmLeave.ts
+++ b/src/utils/confirmLeave.ts
@@ -1,0 +1,7 @@
+export const UNSAVED_LEAVE_MESSAGE =
+  "작성하신 내용은 저장되지 않습니다.\n이 페이지를 떠나시겠습니까?";
+
+/** 작성/수정 중인 페이지를 벗어나기 전 확인한다. */
+export function confirmLeave(): boolean {
+  return window.confirm(UNSAVED_LEAVE_MESSAGE);
+}


### PR DESCRIPTION
## Summary
- 블로그 목록 카드·카테고리 칩·기본 썸네일·비공개 스타일 등 목록 UI를 정리했습니다.
- 블로그 상세/작성 UI를 개선하고, 첨부파일 목록을 공통 `AttachmentList`로 통일했습니다.
- 블로그·장부 목록에서 상세로 갔다가 돌아올 때 이전 스크롤 위치를 복원합니다.
- 저장 완료를 `alert` 대신 토스트로 바꾸고, 작성 중 이탈 확인을 통일했습니다.
- 마크다운 에디터에 표 삽입을 추가하고 편집 영역 높이를 키웠습니다.