### PR TITLE
Desing/attach file design

### DIFF
--- a/src/components/Ledger/LedgerComponents.tsx
+++ b/src/components/Ledger/LedgerComponents.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { getPresignedDownloadURL } from "../../utils/s3Upload";
+import DetailAttachments from "../common/DetailAttachments";
 
 // 공통 아이콘 리소스
 export const pushPinIcon = new URL(
@@ -64,14 +65,21 @@ export interface LedgerDetailMetaProps {
   author: string;
   term: string;
   date: string;
+  /** 첨부 없을 때 본문과 구분할 하단 선 */
+  showBottomBorder?: boolean;
 }
 
 export const LedgerDetailMeta: React.FC<LedgerDetailMetaProps> = ({
   author,
   term,
   date,
+  showBottomBorder = false,
 }) => (
-  <div className="mt-6 flex flex-wrap items-center gap-2 border-b border-gray-200 pb-6 text-sm text-gray-400">
+  <div
+    className={`mt-6 flex flex-wrap items-center gap-2 text-sm text-gray-400 ${
+      showBottomBorder ? "border-b border-gray-200 pb-6" : ""
+    }`}
+  >
     <span className="font-medium text-gray-500">
       {term ? `${term} ` : ""}
       {author}
@@ -92,60 +100,20 @@ export interface LedgerDetailFilesProps {
 export const LedgerDetailFiles: React.FC<LedgerDetailFilesProps> = ({
   fileUrls = [],
 }) => {
-  const [loadingFile, setLoadingFile] = useState<string | null>(null);
-
-  const handleFileClick = async (
-    fileUrl: string,
-    fileName: string,
-    e: React.MouseEvent
-  ) => {
-    e.preventDefault();
-    if (loadingFile === fileUrl) return;
-
-    try {
-      setLoadingFile(fileUrl);
-      const presignedUrl = await getPresignedDownloadURL(fileUrl);
-      const link = document.createElement("a");
-      link.href = presignedUrl;
-      link.download = fileName;
-      link.target = "_blank";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } catch (error) {
-      console.error("파일 다운로드 실패:", error);
-      alert("파일 다운로드에 실패했습니다.");
-    } finally {
-      setLoadingFile(null);
-    }
-  };
-
   if (fileUrls.length === 0) return null;
 
+  const files = fileUrls.map((url) => {
+    const fullFileName = url.split("/").pop() || "첨부파일";
+    const name = fullFileName.replace(/^\d+_\d+_/, "");
+    return { url, name };
+  });
+
   return (
-    <div className="mt-10 border-t border-gray-200 pt-6">
-      <ul className="space-y-2">
-        {fileUrls.map((fileUrl, index) => {
-          const fullFileName = fileUrl.split("/").pop() || "첨부파일";
-          const fileName = fullFileName.replace(/^\d+_\d+_/, "");
-          const isLoading = loadingFile === fileUrl;
-          return (
-            <li key={index} className="flex items-center gap-2 text-sm text-gray-600">
-              <img src={attachFileIcon} alt="" className="w-4 h-4 shrink-0" />
-              <button
-                type="button"
-                onClick={(e) => handleFileClick(fileUrl, fileName, e)}
-                disabled={isLoading}
-                className={`text-left font-medium text-[#007AEB] hover:underline disabled:opacity-50 disabled:cursor-wait ${
-                  isLoading ? "" : "cursor-pointer"
-                }`}
-              >
-                {isLoading ? "다운로드 중..." : fileName}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+    <div className="mt-4 border-b border-gray-200 pb-6">
+      <DetailAttachments
+        files={files}
+        onResolveUrl={async (file) => getPresignedDownloadURL(file.url)}
+      />
     </div>
   );
 };

--- a/src/components/common/DetailAttachments.tsx
+++ b/src/components/common/DetailAttachments.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+
+const attachFileIcon = new URL("../../assets/attach_file.svg", import.meta.url).href;
+
+export interface DetailAttachment {
+  url: string;
+  name: string;
+}
+
+interface DetailAttachmentsProps {
+  files: DetailAttachment[];
+  /** 클릭 시 다운로드 URL 반환. mock 등은 reject 하면 된다. */
+  onResolveUrl: (file: DetailAttachment) => Promise<string>;
+  className?: string;
+}
+
+/** 장부·블로그 상세 공유 첨부 목록 (아이콘 + 파란 링크, 박스 없음) */
+const DetailAttachments: React.FC<DetailAttachmentsProps> = ({
+  files,
+  onResolveUrl,
+  className = "",
+}) => {
+  const [loadingUrl, setLoadingUrl] = useState<string | null>(null);
+
+  if (!files.length) return null;
+
+  const handleClick = async (file: DetailAttachment) => {
+    if (loadingUrl === file.url) return;
+    try {
+      setLoadingUrl(file.url);
+      const downloadUrl = await onResolveUrl(file);
+      const link = document.createElement("a");
+      link.href = downloadUrl;
+      link.download = file.name;
+      link.target = "_blank";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      console.error("파일 다운로드 실패:", error);
+      alert("파일 다운로드에 실패했습니다.");
+    } finally {
+      setLoadingUrl(null);
+    }
+  };
+
+  return (
+    <ul className={`space-y-2 ${className}`}>
+      {files.map((file, index) => {
+        const isLoading = loadingUrl === file.url;
+        return (
+          <li key={`${file.url}-${index}`} className="flex items-center gap-2 text-sm text-gray-600">
+            <img src={attachFileIcon} alt="" className="h-4 w-4 shrink-0" />
+            <button
+              type="button"
+              onClick={() => handleClick(file)}
+              disabled={isLoading}
+              className={`text-left font-medium text-[#007AEB] hover:underline disabled:cursor-wait disabled:opacity-50 ${
+                isLoading ? "" : "cursor-pointer"
+              }`}
+            >
+              {isLoading ? "다운로드 중..." : file.name}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default DetailAttachments;

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -8,7 +8,7 @@ import Navbar from "../components/NavBar";
 import Footer from "../components/MainPage/Footer";
 import BlogImage from "../components/Blog/BlogImage";
 import MarkdownView from "../components/Blog/MarkdownView";
-import AttachmentList from "../components/common/AttachmentList";
+import DetailAttachments from "../components/common/DetailAttachments";
 import ScrollToTopButton from "../components/common/ScrollToTopButton";
 import { BLOG_CATEGORY_MAP, blogCategoryLabel } from "../components/Blog/categories";
 import { useAuth } from "../hooks/useAuth";
@@ -49,36 +49,14 @@ const BlogDetailPage: React.FC = () => {
     query: { enabled: Number.isFinite(id) },
   });
   const { mutateAsync: removeBlog, isPending: isDeleting } = useDeleteBlog();
-  const [loadingFile, setLoadingFile] = useState<string | null>(null);
 
   const post = data?.data as BlogDetailResponse | undefined;
   const cat = post?.category ? BLOG_CATEGORY_MAP[post.category] : undefined;
-  // 본문 마크다운에 이미 인라인으로 들어간 이미지는 하단 갤러리에서 제외(중복 방지)
   const leftoverImages = (post?.imageUrls ?? []).filter(
     (u) => !(post?.content ?? "").includes(u)
   );
-
-  // 첨부는 저장된 값이 S3 key 일 수 있어 클릭 시점에 열 수 있는 주소로 바꿔서 내려받는다
-  const handleFileClick = async (fileUrl: string, e: React.MouseEvent) => {
-    e.preventDefault();
-    if (loadingFile === fileUrl) return;
-    try {
-      setLoadingFile(fileUrl);
-      const url = await resolveBlogFileUrl(fileUrl);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = blogFileName(fileUrl);
-      link.target = "_blank";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } catch (error) {
-      console.error("파일 다운로드 실패:", error);
-      alert("파일 다운로드에 실패했습니다.");
-    } finally {
-      setLoadingFile(null);
-    }
-  };
+  const fileUrls = post?.fileUrls ?? [];
+  const hasFiles = fileUrls.length > 0;
 
   const handleDelete = async () => {
     if (!window.confirm("이 게시물을 삭제할까요? 되돌릴 수 없습니다.")) return;
@@ -122,7 +100,6 @@ const BlogDetailPage: React.FC = () => {
           </div>
         ) : post ? (
           <article>
-            {/* 카테고리 + 수정/삭제 */}
             <div className="mb-5 flex items-center justify-between gap-4">
               {cat ? (
                 <span className="inline-flex items-center gap-1.5 rounded-lg bg-[#007AEB]/10 px-3.5 py-1.5 text-sm font-bold text-[#007AEB]">
@@ -162,7 +139,11 @@ const BlogDetailPage: React.FC = () => {
               <p className="mt-3 text-lg font-medium text-[#374151]">{post.subtitle}</p>
             )}
 
-            <div className="mt-6 flex flex-wrap items-center gap-2 border-b border-gray-200 pb-6 text-sm text-gray-400">
+            <div
+              className={`mt-6 flex flex-wrap items-center gap-2 text-sm text-gray-400 ${
+                hasFiles ? "" : "border-b border-gray-200 pb-6"
+              }`}
+            >
               <span className="font-medium text-gray-500">
                 {post.writerGrade ? `${post.writerGrade}기 ` : ""}
                 {post.writerName}
@@ -177,10 +158,20 @@ const BlogDetailPage: React.FC = () => {
               )}
             </div>
 
-            {/* 본문: 마크다운 렌더 (인라인 이미지는 삽입 위치에 그대로 표시) */}
+            {hasFiles && (
+              <div className="mt-4 border-b border-gray-200 pb-6">
+                <DetailAttachments
+                  files={fileUrls.map((url) => ({
+                    url,
+                    name: blogFileName(url) || "첨부파일",
+                  }))}
+                  onResolveUrl={(file) => resolveBlogFileUrl(file.url)}
+                />
+              </div>
+            )}
+
             <MarkdownView content={post.content ?? ""} className="mt-8" />
 
-            {/* 본문에 인라인으로 포함되지 않은 이미지(레거시 게시물 보강)만 하단에 렌더 */}
             {leftoverImages.length > 0 && (
               <div className="mt-8 flex flex-col gap-4">
                 {leftoverImages.map((url, i) => (
@@ -193,23 +184,6 @@ const BlogDetailPage: React.FC = () => {
                 ))}
               </div>
             )}
-
-            <div className="mt-10 border-t border-gray-200 pt-6">
-              {post.fileUrls && post.fileUrls.length > 0 && (
-                <section className="w-full rounded-xl border border-gray-200 bg-white p-4 lg:max-w-[348px]">
-                  <p className="text-sm font-bold text-gray-700">첨부파일</p>
-                  <AttachmentList
-                    className="mt-3"
-                    items={post.fileUrls.map((url, i) => ({
-                      id: `${url}-${i}`,
-                      name: blogFileName(url) || `첨부파일 ${i + 1}`,
-                      loading: loadingFile === url,
-                      onClick: (e) => handleFileClick(url, e),
-                    }))}
-                  />
-                </section>
-              )}
-            </div>
           </article>
         ) : null}
       </div>

--- a/src/pages/LedgerDetailPage.tsx
+++ b/src/pages/LedgerDetailPage.tsx
@@ -61,7 +61,6 @@ const LedgerDetailPage: React.FC = () => {
     return `${year}. ${month}. ${day} ${hours}:${minutes}`;
   };
 
-  // 회원이 아니면 접근 차단
   useEffect(() => {
     if (!isLoading && !isLoggedIn) {
       navigate("/");
@@ -90,10 +89,8 @@ const LedgerDetailPage: React.FC = () => {
     if (!ledgerId) return;
 
     try {
-      // 1. DB에서 장부 삭제
       await apiDeleteWithToken(`/api/v1/ledgers/${ledgerId}`, navigate);
 
-      // 2. S3에서 파일 삭제 (파일이 있는 경우)
       if (ledger?.fileUrls && ledger.fileUrls.length > 0) {
         try {
           await Promise.all(
@@ -101,7 +98,6 @@ const LedgerDetailPage: React.FC = () => {
           );
         } catch (s3Error) {
           console.error("S3 파일 삭제 실패:", s3Error);
-          // 파일 삭제 실패해도 DB 삭제는 완료되었으므로 계속 진행
         }
       }
 
@@ -127,6 +123,9 @@ const LedgerDetailPage: React.FC = () => {
     );
   }
 
+  const fileUrls = ledger?.fileUrls ?? [];
+  const hasFiles = fileUrls.length > 0;
+
   return (
     <div className="flex flex-col min-h-screen bg-[#FAFAFA]">
       <Navbar />
@@ -145,12 +144,12 @@ const LedgerDetailPage: React.FC = () => {
               author={ledger?.member.name ?? ""}
               term={ledger?.member.grade ? `${ledger.member.grade}기` : ""}
               date={ledger ? formatDateTime(ledger.createdAt) : ""}
+              showBottomBorder={!hasFiles}
             />
+            <LedgerDetailFiles fileUrls={fileUrls} />
             <LedgerDetailContent content={ledger?.content ?? ""} />
-            <LedgerDetailFiles fileUrls={ledger?.fileUrls ?? []} />
           </article>
 
-          {/* 하단 목록 버튼 */}
           <div className="flex justify-start mt-12">
             <button
               type="button"


### PR DESCRIPTION
## Summary
- 블로그·장부 상세 첨부파일을 장부 형식(아이콘 + 파란 파일명)으로 통일
- 첨부 위치를 본문 하단에서 **작성자/작성일과 본문 사이**로 이동
- 작성자–첨부 사이 구분선 제거, 첨부–본문 사이 구분선 추가