### PR TITLE
feat: 메인 페이지 40.5기 모집 버튼 활성화

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -409,16 +409,21 @@ const MainPage = () => {
           className="flex flex-col justify-center items-center px-4 py-16 w-full min-h-screen text-center md:py-24 snap-start"
         >
           {/* 메인 메시지 */}
-          <div className="mb-10 text-xl font-extrabold text-center text-gray-800 md:text-3xl">
+          <div className="mb-3 text-xl font-extrabold text-center text-gray-800 md:text-3xl">
             캡스의 프로그래밍 꿈나무가 되어 1987년의 역사를 이어가주세요.
           </div>
+          <div className="mb-4 text-sm font-semibold text-gray-500 md:text-base">
+            모집 기한: 8월 20일 ~ 9월 2일 23:59
+          </div>
           {/* 버튼 */}
-          <button
-            disabled
-            className="flex items-center px-8 py-4 text-lg font-extrabold text-white bg-blue-600 rounded-full shadow-lg transition cursor-not-allowed opacity-60 md:px-12 md:py-5 md:text-xl disabled:hover:bg-blue-600"
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScKtJH3FQGKAB9uf910VUuIGG6Du-m9fizI9Ml4ag4c8-_6_w/viewform"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center px-8 py-4 text-lg font-extrabold text-white bg-blue-600 rounded-full shadow-lg transition hover:bg-blue-700 md:px-12 md:py-5 md:text-xl"
           >
-            아직은 지원기간이 아니에요!
-          </button>
+            지원서 작성하기 →
+          </a>
         </motion.section>
         <motion.div
           initial={{ opacity: 0, y: 40 }}


### PR DESCRIPTION
## Summary
- 하단 CTA 버튼 활성화: '아직은 지원기간이 아니에요' → '지원서 작성하기 →' (Google Forms 링크 연결)
- 모집 기한 안내 텍스트 추가 (8월 20일 ~ 9월 2일 23:59)

## 배포 일정
- **8월 20일 00:00** 배포 필요
- **9월 2일 24:00 (모집 마감 후)** 아래 항목 롤백 필요:
  - CTA 버튼 비활성화 (`disabled`, 텍스트 '아직은 지원기간이 아니에요!'로 복원)
  - 모집 기한 텍스트 제거